### PR TITLE
Accept several artifact types on one input port

### DIFF
--- a/apps/api/src/grafy_api/execution/compiler.py
+++ b/apps/api/src/grafy_api/execution/compiler.py
@@ -1,5 +1,5 @@
 from collections import Counter, deque
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 from uuid import UUID
@@ -39,6 +39,7 @@ from grafy_core.domain.plugin_selection import PluginReleaseSelection
 from grafy_core.domain.plugin_revocations import PluginReleaseRevocation
 from grafy_core.domain.saved_graphs import SavedGraphPluginReleasePin
 from grafy_core.nodes import (
+    ArtifactTypeVariable,
     Node,
     NodeContractResolutionError,
     PortShape,
@@ -795,6 +796,10 @@ def _validate_input_plugs(
             )
 
 
+def _artifact_type_keys_label(keys: Sequence[ArtifactTypeKey]) -> str:
+    return ", ".join(f"{key.id}@{key.schema_version}" for key in keys)
+
+
 def _compile_edges(
     *,
     nodes_by_id: dict[str, Node[Any, Any, Any]],
@@ -821,12 +826,19 @@ def _compile_edges(
                 f"{edge.to_node!r}.{edge.to_port!r} references unknown input "
                 f"port {edge.to_port!r} on node {edge.to_node!r}"
             )
-        target_key = target_port.accepts
-        if not isinstance(target_key, ArtifactTypeKey):
+        target_keys = target_port.accepted_types
+        if not target_keys:
+            if isinstance(target_port.accepts, ArtifactTypeVariable):
+                raise GraphExecutionError(
+                    f"Node {edge.to_node!r} input {edge.to_port!r} retained "
+                    f"unresolved artifact type variable "
+                    f"{target_port.accepts.name!r}"
+                )
             raise GraphExecutionError(
-                f"Node {edge.to_node!r} input {edge.to_port!r} retained "
-                f"unresolved artifact type variable {target_key.name!r}"
+                f"Node {edge.to_node!r} input {edge.to_port!r} declares no "
+                "accepted artifact types"
             )
+        target_label = _artifact_type_keys_label(target_keys)
 
         source_node = nodes_by_id.get(edge.from_node)
         if source_node is None:
@@ -947,7 +959,7 @@ def _compile_edges(
             effective_source_key = conversion.target
             seen_artifact_keys.add(effective_source_key)
 
-        if effective_source_key != target_key:
+        if effective_source_key not in target_keys:
             if resolved_conversions:
                 conversion_path = " -> ".join(
                     f"{conversion.key.id}@{conversion.key.version}"
@@ -959,7 +971,7 @@ def _compile_edges(
                     f"{conversion_path} as "
                     f"{effective_source_key.id}@"
                     f"{effective_source_key.schema_version}, but target expects "
-                    f"{target_key.id}@{target_key.schema_version}"
+                    f"{target_label}"
                 )
             if edge.projection is not None:
                 raise GraphExecutionError(
@@ -968,14 +980,14 @@ def _compile_edges(
                     f"{'.'.join(edge.projection.path)!r} as "
                     f"{effective_source_key.id}@"
                     f"{effective_source_key.schema_version}, but target expects "
-                    f"{target_key.id}@{target_key.schema_version}"
+                    f"{target_label}"
                 )
             raise GraphExecutionError(
                 f"Edge {edge.from_node!r}.{edge.from_port!r} -> "
                 f"{edge.to_node!r}.{edge.to_port!r} cannot connect "
                 f"{effective_source_key.id}@"
                 f"{effective_source_key.schema_version} to "
-                f"{target_key.id}@{target_key.schema_version} "
+                f"{target_label} "
                 "without a declared field projection or conversion"
             )
 

--- a/apps/api/src/grafy_api/execution/node_execution.py
+++ b/apps/api/src/grafy_api/execution/node_execution.py
@@ -219,7 +219,8 @@ class NodeExecutionService:
             )
 
         input_port = compiled_node.resolved_contracts.input_contract.ports[map_input]
-        if not isinstance(input_port.accepts, ArtifactTypeKey):
+        accepted_types = input_port.accepted_types
+        if not accepted_types:
             raise InvocationError(
                 f"Node {node.operator_id!r} MAP input {map_input!r} has an "
                 "unresolved artifact type contract"
@@ -228,10 +229,13 @@ class NodeExecutionService:
             raw_sequence.artifact_type,
             raw_sequence.schema_version,
         )
-        if sequence_key != input_port.accepts:
+        if sequence_key not in accepted_types:
+            expected = ", ".join(
+                f"{key.id}@{key.schema_version}" for key in accepted_types
+            )
             raise InvocationError(
                 f"Node {node.operator_id!r} MAP input {map_input!r} expected "
-                f"{input_port.accepts.id}@{input_port.accepts.schema_version}, got "
+                f"{expected}, got "
                 f"{sequence_key.id}@{sequence_key.schema_version}"
             )
 

--- a/apps/api/src/grafy_api/plugins/runtime/admission.py
+++ b/apps/api/src/grafy_api/plugins/runtime/admission.py
@@ -234,19 +234,20 @@ class ReleaseExecutionAdmission:
                         f"type variable {port.artifact_type_variable!r}"
                     )
                     continue
-                key = (port.artifact_type.id, port.artifact_type.schema_version)
-                artifact_contract = artifact_contracts.get(key)
-                if artifact_contract is None:
-                    unsupported_types.add(f"{key[0]}@{key[1]} (undeclared)")
-                    continue
-                adapter = (
-                    artifact_contract.bundle.format,
-                    artifact_contract.bundle.version,
-                )
-                if adapter not in self.supported_bundle_adapters:
-                    unsupported_types.add(
-                        f"{key[0]}@{key[1]} ({adapter[0]}@{adapter[1]})"
+                for accepted in port.accepted_types:
+                    key = (accepted.id, accepted.schema_version)
+                    artifact_contract = artifact_contracts.get(key)
+                    if artifact_contract is None:
+                        unsupported_types.add(f"{key[0]}@{key[1]} (undeclared)")
+                        continue
+                    adapter = (
+                        artifact_contract.bundle.format,
+                        artifact_contract.bundle.version,
                     )
+                    if adapter not in self.supported_bundle_adapters:
+                        unsupported_types.add(
+                            f"{key[0]}@{key[1]} ({adapter[0]}@{adapter[1]})"
+                        )
         if unsupported_types:
             return ReleaseExecutionRejection(
                 reason="unsupported_artifact_type",

--- a/apps/api/src/grafy_api/v1/routes/catalog/models.py
+++ b/apps/api/src/grafy_api/v1/routes/catalog/models.py
@@ -262,6 +262,7 @@ class PortResponse(ApiResponse):
     direction: PortDirection
     artifact_type: ArtifactTypeKeyResponse | None = None
     artifact_type_variable: ArtifactTypeVariableIdentifier | None = None
+    also_accepts: list[ArtifactTypeKeyResponse] = Field(default_factory=list)
     shape: PortShape
     accepted_shapes: list[PortShape]
     instance_plugs: bool = False
@@ -274,6 +275,10 @@ class PortResponse(ApiResponse):
             raise ValueError(
                 "Port must declare exactly one of artifact_type or "
                 "artifact_type_variable"
+            )
+        if self.also_accepts and self.artifact_type is None:
+            raise ValueError(
+                "Port additional accepted artifact types require an artifact_type"
             )
         return self
 
@@ -294,6 +299,9 @@ class PortResponse(ApiResponse):
             direction="input",
             artifact_type=artifact_type,
             artifact_type_variable=artifact_type_variable,
+            also_accepts=[
+                ArtifactTypeKeyResponse.from_key(key) for key in port.also_accepts
+            ],
             shape=port.shape,
             accepted_shapes=list(port.accepted_shapes),
             instance_plugs=port.instance_plugs,
@@ -342,6 +350,13 @@ class PortResponse(ApiResponse):
             direction=port.direction,
             artifact_type=artifact_type,
             artifact_type_variable=port.artifact_type_variable,
+            also_accepts=[
+                ArtifactTypeKeyResponse(
+                    id=key.id,
+                    schema_version=key.schema_version,
+                )
+                for key in port.also_accepts
+            ],
             shape=port.shape,
             accepted_shapes=list(port.accepted_shapes),
             instance_plugs=port.instance_plugs,

--- a/apps/web/openapi/grafy.json
+++ b/apps/web/openapi/grafy.json
@@ -4271,6 +4271,13 @@
             "title": "Accepted Shapes",
             "type": "array"
           },
+          "also_accepts": {
+            "items": {
+              "$ref": "#/components/schemas/ArtifactTypeKeyResponse"
+            },
+            "title": "Also Accepts",
+            "type": "array"
+          },
           "artifact_type": {
             "anyOf": [
               {

--- a/apps/web/src/features/workbench/canvas/handles.test.ts
+++ b/apps/web/src/features/workbench/canvas/handles.test.ts
@@ -9,6 +9,7 @@ import {
   MAX_CONVERSION_PATH_CANDIDATES,
   MAX_CONVERSION_PATH_LENGTH,
   canonicalHandleId,
+  connectionIsValid,
   connectionRouteForSelection,
   connectionRouteSelection,
   connectionRoutesFor,
@@ -574,5 +575,94 @@ describe("conversion route discovery", () => {
     );
 
     expect(routes).toEqual([{ kind: "exact", conversionPath: [] }]);
+  });
+});
+
+describe("multi-type input ports", () => {
+  const multiTypeTarget = encodeHandleId({
+    portName: "file",
+    artifactTypeId: "file.csv",
+    schemaVersion: 1,
+    shape: "one",
+    direction: "input",
+    alsoAccepts: [{ id: "file.xlsx", schema_version: 1 }],
+  });
+
+  function source(id: string): string {
+    return encodeHandleId({
+      portName: "output",
+      artifactTypeId: id,
+      schemaVersion: 1,
+      shape: "one",
+      direction: "output",
+    });
+  }
+
+  it("round-trips the additional accepted artifact types", () => {
+    const decoded = decodeHandleId(multiTypeTarget);
+
+    expect(decoded).toMatchObject({
+      artifactTypeId: "file.csv",
+      alsoAccepts: [{ id: "file.xlsx", schema_version: 1 }],
+    });
+    expect(encodeHandleId(decoded!)).toBe(multiTypeTarget);
+  });
+
+  it("accepts an edge of either declared artifact type", () => {
+    expect(
+      connectionRoutesFor(
+        { sourceHandle: source("file.csv"), targetHandle: multiTypeTarget },
+        [],
+        [],
+      ),
+    ).toEqual([{ kind: "exact", conversionPath: [] }]);
+    expect(
+      connectionRoutesFor(
+        { sourceHandle: source("file.xlsx"), targetHandle: multiTypeTarget },
+        [],
+        [],
+      ),
+    ).toEqual([{ kind: "exact", conversionPath: [] }]);
+  });
+
+  it("refuses a third artifact type", () => {
+    expect(
+      connectionRoutesFor(
+        { sourceHandle: source("file.pdf"), targetHandle: multiTypeTarget },
+        [],
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  it("accepts a declared conversion to a member of the set", () => {
+    const pdfToXlsx = conversion(
+      "builtin.file.pdf_to_xlsx",
+      "file.pdf",
+      "file.xlsx",
+    );
+
+    expect(
+      connectionRoutesFor(
+        { sourceHandle: source("file.pdf"), targetHandle: multiTypeTarget },
+        [],
+        [pdfToXlsx],
+      ),
+    ).toEqual([{ kind: "conversion", conversionPath: [pdfToXlsx] }]);
+  });
+
+  it("validates a drag connection against any member of the set", () => {
+    expect(
+      connectionIsValid({
+        sourceHandle: source("file.xlsx"),
+        targetHandle: multiTypeTarget,
+      }),
+    ).toBe(true);
+    expect(
+      connectionIsValid({
+        sourceHandle: source("file.pdf"),
+        targetHandle: multiTypeTarget,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/features/workbench/canvas/handles.ts
+++ b/apps/web/src/features/workbench/canvas/handles.ts
@@ -10,10 +10,48 @@ import type { HandleFeedIntent, PortMeta } from "./types";
 export type { HandleFeedIntent };
 
 const HANDLE_FEED_PREFIX = "feed=";
+const HANDLE_ALSO_ACCEPTS_PREFIX = "also=";
 
 function encodeHandleFeedSegment(feed: HandleFeedIntent): string {
   if (feed.kind === "whole") return `${HANDLE_FEED_PREFIX}whole`;
   return `${HANDLE_FEED_PREFIX}proj/${feed.path.map(encodeURIComponent).join("/")}`;
+}
+
+/** Encode the additional accepted artifact types of one input port handle. */
+function encodeHandleAlsoAcceptsSegment(
+  accepted: readonly ArtifactTypeKey[],
+): string {
+  return `${HANDLE_ALSO_ACCEPTS_PREFIX}${accepted
+    .map((key) => encodeURIComponent(`${key.id}@${key.schema_version}`))
+    .join(",")}`;
+}
+
+function decodeHandleAlsoAcceptsSegment(
+  segment: string,
+): ArtifactTypeKey[] | null {
+  const body = segment.slice(HANDLE_ALSO_ACCEPTS_PREFIX.length);
+  if (!body) return null;
+  try {
+    return body.split(",").map((entry) => {
+      const decoded = decodeURIComponent(entry);
+      const separator = decoded.lastIndexOf("@");
+      const id = decoded.slice(0, separator);
+      const schemaVersion = Number(decoded.slice(separator + 1));
+      if (separator <= 0 || !id || !Number.isInteger(schemaVersion)) {
+        throw new Error("invalid accepted artifact type");
+      }
+      return { id, schema_version: schemaVersion };
+    });
+  } catch {
+    return null;
+  }
+}
+
+function isHandleAlsoAcceptsSegment(segment: string | undefined): boolean {
+  return (
+    typeof segment === "string" &&
+    segment.startsWith(HANDLE_ALSO_ACCEPTS_PREFIX)
+  );
 }
 
 function decodeHandleFeedSegment(segment: string): HandleFeedIntent | null {
@@ -60,6 +98,9 @@ export function encodeHandleId(port: PortMeta): string {
         port.direction,
       ];
   if (port.plugId) parts.push(port.plugId);
+  if (port.alsoAccepts?.length) {
+    parts.push(encodeHandleAlsoAcceptsSegment(port.alsoAccepts));
+  }
   if (port.feed) parts.push(encodeHandleFeedSegment(port.feed));
   return parts.join("::");
 }
@@ -80,6 +121,7 @@ interface DecodedHandleBase {
   direction: PortMeta["direction"];
   plugId?: string;
   feed?: HandleFeedIntent;
+  alsoAccepts?: ArtifactTypeKey[];
 }
 
 interface DecodedConcreteHandle extends DecodedHandleBase {
@@ -101,7 +143,7 @@ export function decodeHandleId(
 ): DecodedHandle | null {
   if (!id) return null;
   const p = id.split("::");
-  if (p.length < 5 || p.length > 7) return null;
+  if (p.length < 5 || p.length > 8) return null;
   const shape = p[3];
   const direction = p[4];
   if (shape !== "one" && shape !== "many") return null;
@@ -109,22 +151,24 @@ export function decodeHandleId(
 
   let plugId: string | undefined;
   let feed: HandleFeedIntent | undefined;
-  if (p.length === 6) {
-    if (isHandleFeedSegment(p[5])) {
-      const decodedFeed = decodeHandleFeedSegment(p[5]!);
+  let alsoAccepts: ArtifactTypeKey[] | undefined;
+  for (const segment of p.slice(5)) {
+    if (isHandleFeedSegment(segment)) {
+      if (feed) return null;
+      const decodedFeed = decodeHandleFeedSegment(segment);
       if (!decodedFeed) return null;
       feed = decodedFeed;
-    } else if (p[5]) {
-      plugId = p[5];
-    } else {
-      return null;
+      continue;
     }
-  } else if (p.length === 7) {
-    if (!p[5] || !isHandleFeedSegment(p[6])) return null;
-    const decodedFeed = decodeHandleFeedSegment(p[6]!);
-    if (!decodedFeed) return null;
-    plugId = p[5];
-    feed = decodedFeed;
+    if (isHandleAlsoAcceptsSegment(segment)) {
+      if (alsoAccepts) return null;
+      const decodedAccepted = decodeHandleAlsoAcceptsSegment(segment);
+      if (!decodedAccepted) return null;
+      alsoAccepts = decodedAccepted;
+      continue;
+    }
+    if (!segment || plugId) return null;
+    plugId = segment;
   }
 
   if (p[2] === "$generic") {
@@ -153,6 +197,7 @@ export function decodeHandleId(
     shape,
     direction,
     ...(plugId ? { plugId } : {}),
+    ...(alsoAccepts ? { alsoAccepts } : {}),
     ...(feed ? { feed } : {}),
   };
 }
@@ -172,6 +217,24 @@ export function decodedHandleArtifactType(
   };
 }
 
+/** Concrete artifact types one decoded handle accepts, primary type first. */
+export function acceptedHandleArtifactTypes(
+  handle: DecodedHandle,
+): ArtifactTypeKey[] {
+  const primary = decodedHandleArtifactType(handle);
+  if (!primary) return [];
+  return [primary, ...(handle.alsoAccepts ?? [])];
+}
+
+function handleAcceptsArtifactType(
+  handle: DecodedHandle,
+  artifactType: ArtifactTypeKey,
+): boolean {
+  return acceptedHandleArtifactTypes(handle).some(
+    (candidate) => artifactTypeKey(candidate) === artifactTypeKey(artifactType),
+  );
+}
+
 /** A connection is valid when the output and input share an artifact contract. */
 export function connectionIsValid(connection: {
   sourceHandle?: string | null;
@@ -188,7 +251,7 @@ export function connectionIsValid(connection: {
     t.direction === "input" &&
     (!sourceArtifactType ||
       !targetArtifactType ||
-      artifactTypeKey(sourceArtifactType) === artifactTypeKey(targetArtifactType)) &&
+      handleAcceptsArtifactType(t, sourceArtifactType)) &&
     s.shape === t.shape
   );
 }
@@ -207,7 +270,7 @@ export function connectionArtifactContractIsValid(connection: {
   return (
     source.direction === "output" &&
     target.direction === "input" &&
-    artifactTypeKey(sourceArtifactType) === artifactTypeKey(targetArtifactType)
+    handleAcceptsArtifactType(target, sourceArtifactType)
   );
 }
 
@@ -234,7 +297,7 @@ export function projectionCandidatesForConnection(
     !targetArtifactType ||
     source.direction !== "output" ||
     target.direction !== "input" ||
-    artifactTypeKey(sourceArtifactType) === artifactTypeKey(targetArtifactType)
+    handleAcceptsArtifactType(target, sourceArtifactType)
   ) {
     return [];
   }
@@ -245,10 +308,8 @@ export function projectionCandidatesForConnection(
   );
   if (!sourceArtifact?.field_projections) return [];
 
-  return sourceArtifact.field_projections.filter(
-    (projection) =>
-      artifactTypeKey(projection.target_artifact_type) ===
-      artifactTypeKey(targetArtifactType),
+  return sourceArtifact.field_projections.filter((projection) =>
+    handleAcceptsArtifactType(target, projection.target_artifact_type),
   );
 }
 
@@ -391,6 +452,20 @@ function shortestConversionPaths(
   // Reaching the hop bound leaves the registry search incomplete, so no route
   // is advertised instead of guessing that a longer chain is safe.
   return [];
+}
+
+function shortestConversionPathsToAny(
+  source: { id: string; schema_version: number },
+  targets: readonly { id: string; schema_version: number }[],
+  conversions: readonly ArtifactConversionSpec[],
+): ArtifactConversionSpec[][] | null {
+  const paths: ArtifactConversionSpec[][] = [];
+  for (const target of targets) {
+    const targetPaths = shortestConversionPaths(source, target, conversions);
+    if (targetPaths === null) return null;
+    paths.push(...targetPaths);
+  }
+  return paths;
 }
 
 function connectionRoute(
@@ -545,8 +620,12 @@ export function connectionRoutesFor(
   }
   if (!sourceArtifactType || !targetArtifactType) return [];
 
+  const targetArtifactTypes = acceptedHandleArtifactTypes(target);
   if (
-    artifactTypeKey(sourceArtifactType) === artifactTypeKey(targetArtifactType)
+    targetArtifactTypes.some(
+      (candidate) =>
+        artifactTypeKey(candidate) === artifactTypeKey(sourceArtifactType),
+    )
   ) {
     return [{ kind: "exact", conversionPath: [] }];
   }
@@ -555,9 +634,9 @@ export function connectionRoutesFor(
     (artifact) =>
       artifactTypeKey(artifact.key) === artifactTypeKey(sourceArtifactType),
   );
-  const wholeOutputPaths = shortestConversionPaths(
+  const wholeOutputPaths = shortestConversionPathsToAny(
     sourceArtifactType,
-    targetArtifactType,
+    targetArtifactTypes,
     conversions,
   );
   if (wholeOutputPaths === null) return [];
@@ -572,9 +651,9 @@ export function connectionRoutesFor(
       left.title.localeCompare(right.title),
   );
   for (const projection of projections) {
-    const conversionPaths = shortestConversionPaths(
+    const conversionPaths = shortestConversionPathsToAny(
       projection.target_artifact_type,
-      targetArtifactType,
+      targetArtifactTypes,
       conversions,
     );
     if (conversionPaths === null) return [];
@@ -668,10 +747,12 @@ export function connectionRouteForSelection(
   }
 
   if (
-    !artifactTypeMatches(
-      currentArtifactType,
-      targetArtifactType.id,
-      targetArtifactType.schema_version,
+    !acceptedHandleArtifactTypes(target).some((candidate) =>
+      artifactTypeMatches(
+        currentArtifactType,
+        candidate.id,
+        candidate.schema_version,
+      ),
     )
   ) {
     return null;

--- a/apps/web/src/features/workbench/canvas/types.ts
+++ b/apps/web/src/features/workbench/canvas/types.ts
@@ -120,6 +120,8 @@ interface PortMetaBase {
   plugId?: string;
   /** Connect-time only; catalog satellites. Never persisted on saved edges. */
   feed?: HandleFeedIntent;
+  /** Additional artifact types an input port accepts, after the primary one. */
+  alsoAccepts?: readonly ArtifactTypeKey[];
 }
 
 /** Metadata encoded into React Flow handle ids for typed connections. */
@@ -588,10 +590,12 @@ export function portMetaForPort(
     ...(plugId ? { plugId } : {}),
   };
   if (artifactType) {
+    const alsoAccepts = port.also_accepts ?? [];
     return {
       ...base,
       artifactTypeId: artifactType.id,
       schemaVersion: artifactType.schema_version,
+      ...(alsoAccepts.length ? { alsoAccepts } : {}),
     };
   }
 

--- a/apps/web/src/lib/api/generated/grafy.ts
+++ b/apps/web/src/lib/api/generated/grafy.ts
@@ -2644,6 +2644,8 @@ export interface components {
         readonly PortResponse: {
             /** Accepted Shapes */
             readonly accepted_shapes: readonly components["schemas"]["PortShape"][];
+            /** Also Accepts */
+            readonly also_accepts?: readonly components["schemas"]["ArtifactTypeKeyResponse"][];
             readonly artifact_type?: components["schemas"]["ArtifactTypeKeyResponse"] | null;
             /** Artifact Type Variable */
             readonly artifact_type_variable?: string | null;

--- a/libs/client/src/grafy_client/graph_builder.py
+++ b/libs/client/src/grafy_client/graph_builder.py
@@ -168,6 +168,7 @@ class GraphBuilder:
                     port.instance_plugs,
                     port.variadic,
                     port.required,
+                    port.also_accepts,
                 )
             )
         for port in node_class.output_contract.ports.values():
@@ -192,6 +193,7 @@ class GraphBuilder:
                     False,
                     False,
                     port.required,
+                    (),
                 )
             )
         catalog_ports = [
@@ -205,6 +207,7 @@ class GraphBuilder:
                 port.instance_plugs,
                 port.variadic,
                 port.required,
+                port.also_accepts,
             )
             for port in (*catalog_node.inputs, *catalog_node.outputs)
         ]

--- a/libs/client/src/grafy_client/models.py
+++ b/libs/client/src/grafy_client/models.py
@@ -27,6 +27,7 @@ class CatalogPort(ClientModel):
     direction: Literal["input", "output"]
     artifact_type: ArtifactTypeKey | None = None
     artifact_type_variable: str | None = None
+    also_accepts: tuple[ArtifactTypeKey, ...] = ()
     shape: PortShape
     accepted_shapes: tuple[PortShape, ...]
     instance_plugs: bool = False
@@ -38,6 +39,11 @@ class CatalogPort(ClientModel):
         if (self.artifact_type is None) == (self.artifact_type_variable is None):
             raise ValueError(
                 "Catalog port must declare exactly one artifact type or variable"
+            )
+        if self.also_accepts and self.artifact_type is None:
+            raise ValueError(
+                "Catalog port additional accepted artifact types require an "
+                "artifact type"
             )
         return self
 

--- a/libs/core/src/grafy_core/domain/plugin_releases.py
+++ b/libs/core/src/grafy_core/domain/plugin_releases.py
@@ -57,6 +57,7 @@ def plugin_profile_digest(runtime_profile: str) -> str:
 
 
 _EMPTY_HTTP_EGRESS_SERIALIZATION = ',"http_egress":null'
+_EMPTY_ALSO_ACCEPTS_SERIALIZATION = ',"also_accepts":[]'
 
 
 def plugin_contract_digest(catalog: PluginCatalogManifest) -> str:
@@ -64,12 +65,15 @@ def plugin_contract_digest(catalog: PluginCatalogManifest) -> str:
 
     Absent HTTP-egress declarations are dropped before hashing so a catalog
     parsed with the newer contract fields digests identically to the bytes
-    persisted before that field existed.
+    persisted before that field existed. Absent additional accepted artifact
+    types are dropped for the same reason.
     """
 
     serialized = catalog.model_dump_json()
     if _EMPTY_HTTP_EGRESS_SERIALIZATION in serialized:
         serialized = serialized.replace(_EMPTY_HTTP_EGRESS_SERIALIZATION, "")
+    if _EMPTY_ALSO_ACCEPTS_SERIALIZATION in serialized:
+        serialized = serialized.replace(_EMPTY_ALSO_ACCEPTS_SERIALIZATION, "")
     return sha256(serialized.encode("utf-8")).hexdigest()
 
 
@@ -269,6 +273,7 @@ class PluginPortContract(PluginReleaseValue):
     direction: PluginPortDirection
     artifact_type: PluginArtifactTypeKey | None = None
     artifact_type_variable: str | None = Field(default=None, max_length=255)
+    also_accepts: tuple[PluginArtifactTypeKey, ...] = ()
     shape: PortShape
     accepted_shapes: tuple[PortShape, ...] = Field(min_length=1)
     instance_plugs: bool = False
@@ -281,7 +286,31 @@ class PluginPortContract(PluginReleaseValue):
             raise ValueError(
                 "Plugin port must declare exactly one artifact type or type variable"
             )
+        if not self.also_accepts:
+            return self
+        if self.artifact_type is None:
+            raise ValueError(
+                "Plugin port additional accepted artifact types require a primary "
+                "artifact type"
+            )
+        if self.artifact_type in self.also_accepts:
+            raise ValueError(
+                "Plugin port repeats its primary artifact type among its additional "
+                "accepted artifact types"
+            )
+        if len(set(self.also_accepts)) != len(self.also_accepts):
+            raise ValueError(
+                "Plugin port declares duplicate additional accepted artifact types"
+            )
         return self
+
+    @property
+    def accepted_types(self) -> tuple[PluginArtifactTypeKey, ...]:
+        """Concrete artifact types this port accepts, primary type first."""
+
+        if self.artifact_type is None:
+            return ()
+        return (self.artifact_type, *self.also_accepts)
 
     @classmethod
     def from_input_port(cls, port: InputPortSpec) -> Self:
@@ -300,6 +329,9 @@ class PluginPortContract(PluginReleaseValue):
             direction="input",
             artifact_type=artifact_type,
             artifact_type_variable=artifact_type_variable,
+            also_accepts=tuple(
+                PluginArtifactTypeKey.from_key(key) for key in port.also_accepts
+            ),
             shape=port.shape,
             accepted_shapes=port.accepted_shapes,
             instance_plugs=port.instance_plugs,

--- a/libs/core/src/grafy_core/nodes.py
+++ b/libs/core/src/grafy_core/nodes.py
@@ -92,11 +92,24 @@ ArtifactTypeContract = ArtifactTypeKey | ArtifactTypeVariable
 
 @dataclass(frozen=True, slots=True)
 class InPort:
-    """Marks an input model field as an artifact port via Annotated metadata."""
+    """Marks an input model field as an artifact port via Annotated metadata.
+
+    ``accepts`` is the primary artifact type (or the single artifact type
+    variable). ``also_accepts`` adds the remaining concrete types the same input
+    accepts, so one port can take several artifact types without a type variable.
+    """
 
     accepts: ArtifactTypeSpec | ArtifactTypeContract
     variadic: bool = False
     instance_plugs: bool = False
+    also_accepts: tuple[ArtifactTypeSpec | ArtifactTypeKey, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.also_accepts and isinstance(self.accepts, ArtifactTypeVariable):
+            raise NodeContractError(
+                "An input port must declare either an artifact type variable or "
+                "additional accepted artifact types, not both"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +133,37 @@ class InputPortSpec:
     preserves_ref_container: bool = False
     allows_none: bool = False
     required: bool = True
+    also_accepts: tuple[ArtifactTypeKey, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.also_accepts:
+            return
+        if isinstance(self.accepts, ArtifactTypeVariable):
+            raise NodeContractError(
+                f"Input port {self.name!r} must declare either an artifact type "
+                "variable or additional accepted artifact types, not both"
+            )
+        if self.accepts in self.also_accepts:
+            raise NodeContractError(
+                f"Input port {self.name!r} repeats its primary artifact type "
+                "among its additional accepted artifact types"
+            )
+        if len(set(self.also_accepts)) != len(self.also_accepts):
+            raise NodeContractError(
+                f"Input port {self.name!r} declares duplicate additional accepted "
+                "artifact types"
+            )
+
+    @property
+    def accepted_types(self) -> tuple[ArtifactTypeKey, ...]:
+        """Concrete artifact types this input accepts, primary type first.
+
+        Empty for a port that declares a named artifact type variable.
+        """
+
+        if isinstance(self.accepts, ArtifactTypeVariable):
+            return ()
+        return (self.accepts, *self.also_accepts)
 
 
 @dataclass(frozen=True, slots=True)
@@ -250,6 +294,17 @@ def _artifact_type_contract(
     return value
 
 
+def _concrete_artifact_type_key(value: object) -> ArtifactTypeKey:
+    if isinstance(value, ArtifactTypeSpec):
+        return value.key
+    if isinstance(value, ArtifactTypeKey):
+        return value
+    raise NodeContractError(
+        "Additional accepted artifact types must be concrete artifact types, got "
+        f"{type(value).__name__}"
+    )
+
+
 def derive_input_contract[T: BaseModel](model: type[T]) -> InputContract[T]:
     ports: dict[str, InputPortSpec] = {}
     for name, field in model.model_fields.items():
@@ -272,6 +327,9 @@ def derive_input_contract[T: BaseModel](model: type[T]) -> InputContract[T]:
         ports[name] = InputPortSpec(
             name=name,
             accepts=_artifact_type_contract(port.accepts),
+            also_accepts=tuple(
+                _concrete_artifact_type_key(value) for value in port.also_accepts
+            ),
             title=field.title,
             description=field.description,
             shape=shape,

--- a/libs/core/src/grafy_core/plugins.py
+++ b/libs/core/src/grafy_core/plugins.py
@@ -40,6 +40,7 @@ from grafy_core.domain.modules import (
     MODULE_OUTPUT_OPERATOR_ID,
 )
 from grafy_core.nodes import (
+    ArtifactTypeContract,
     ArtifactTypeVariable,
     ConfigContract,
     Node,
@@ -844,9 +845,10 @@ class PluginRegistry:
                     )
                 }
             )
-            port_contracts = [
-                ("input", port.name, port.accepts)
+            port_contracts: list[tuple[str, str, ArtifactTypeContract]] = [
+                ("input", port.name, artifact_type)
                 for port in registration.node_class.input_contract.ports.values()
+                for artifact_type in port.accepted_types
             ]
             port_contracts.extend(
                 ("output", port.name, port.produces)

--- a/libs/core/src/grafy_core/runtime/materialization.py
+++ b/libs/core/src/grafy_core/runtime/materialization.py
@@ -61,7 +61,8 @@ class InputMaterializer:
                     raise MaterializationError(name, "is required")
                 continue
 
-            if not isinstance(spec.accepts, ArtifactTypeKey):
+            accepted_types = spec.accepted_types
+            if not accepted_types:
                 raise MaterializationError(
                     name,
                     "has an unresolved artifact type contract",
@@ -97,7 +98,7 @@ class InputMaterializer:
                     if isinstance(item, ArtifactRefSequence) and (
                         spec.preserves_ref_container
                     ):
-                        _validate_sequence_key(name, item, spec.accepts)
+                        _validate_sequence_key(name, item, accepted_types)
                         edges.append(list(item.item_refs))
                         continue
                     expected = (
@@ -115,7 +116,7 @@ class InputMaterializer:
                     case False, PortShape.ONE, ArtifactRef() as ref:
                         edges = [[ref]]
                     case False, PortShape.MANY, ArtifactRefSequence() as sequence:
-                        _validate_sequence_key(name, sequence, spec.accepts)
+                        _validate_sequence_key(name, sequence, accepted_types)
                         edges = [list(sequence.item_refs)]
                     case True, PortShape.ONE, list() | tuple():
                         edges = []
@@ -136,7 +137,7 @@ class InputMaterializer:
                                     f"expected one ArtifactRefSequence per incoming "
                                     f"edge, got {type(item).__name__}",
                                 )
-                            _validate_sequence_key(name, item, spec.accepts)
+                            _validate_sequence_key(name, item, accepted_types)
                             edges.append(list(item.item_refs))
                     case _:
                         expected = _EXPECTED_PORT_VALUE[(spec.variadic, spec.shape)]
@@ -150,11 +151,10 @@ class InputMaterializer:
 
             refs = tuple(ref for edge in edges for ref in edge)
             for ref in refs:
-                if ref.key() != spec.accepts:
+                if ref.key() not in accepted_types:
                     raise MaterializationError(
                         name,
-                        f"expected {spec.accepts.id}@"
-                        f"{spec.accepts.schema_version}, got "
+                        f"expected {_artifact_type_keys_label(accepted_types)}, got "
                         f"{ref.artifact_type}@{ref.schema_version}",
                     )
             if len(refs) > 0:
@@ -195,17 +195,19 @@ class InputMaterializer:
         )
 
 
+def _artifact_type_keys_label(keys: Sequence[ArtifactTypeKey]) -> str:
+    return ", ".join(f"{key.id}@{key.schema_version}" for key in keys)
+
+
 def _validate_sequence_key(
     port_name: str,
     sequence: ArtifactRefSequence,
-    expected: ArtifactTypeKey,
+    expected: Sequence[ArtifactTypeKey],
 ) -> None:
-    if sequence.artifact_type == expected.id and (
-        sequence.schema_version == expected.schema_version
-    ):
+    if ArtifactTypeKey(sequence.artifact_type, sequence.schema_version) in expected:
         return
     raise MaterializationError(
         port_name,
-        f"expected {expected.id}@{expected.schema_version}, got "
+        f"expected {_artifact_type_keys_label(expected)}, got "
         f"{sequence.artifact_type}@{sequence.schema_version}",
     )

--- a/libs/core/src/grafy_core/runtime/plugin_guest.py
+++ b/libs/core/src/grafy_core/runtime/plugin_guest.py
@@ -1012,13 +1012,17 @@ def _validate_request_contract(
         )
     for binding in request.inputs:
         spec = input_specs[binding.port]
-        if not isinstance(spec.accepts, ArtifactTypeKey):
+        accepted_types = spec.accepted_types
+        if not accepted_types:
             raise PluginGuestError(
                 f"Input port {binding.port!r} kept an unresolved artifact type"
             )
         if (
-            binding.artifact_type.id != spec.accepts.id
-            or binding.artifact_type.schema_version != spec.accepts.schema_version
+            ArtifactTypeKey(
+                binding.artifact_type.id,
+                binding.artifact_type.schema_version,
+            )
+            not in accepted_types
         ):
             raise PluginGuestError(
                 f"Input port {binding.port!r} artifact type does not match the "
@@ -1086,19 +1090,20 @@ def _plugin_runtime(
     resolvers = [factory(context) for factory in plugin.resolver_factories]
     resolver_keys = {(resolver.source, resolver.target) for resolver in resolvers}
     for spec in input_contract.ports.values():
-        if not isinstance(spec.accepts, ArtifactTypeKey) or spec.target_type is None:
+        if spec.target_type is None:
             continue
-        key = (spec.accepts, spec.target_type)
-        if key in resolver_keys:
-            continue
-        resolvers.append(
-            _GuestInlineResolver(
-                source=spec.accepts,
-                target=spec.target_type,
-                unit_of_work=unit_of_work,
+        for artifact_type in spec.accepted_types:
+            key = (artifact_type, spec.target_type)
+            if key in resolver_keys:
+                continue
+            resolvers.append(
+                _GuestInlineResolver(
+                    source=artifact_type,
+                    target=spec.target_type,
+                    unit_of_work=unit_of_work,
+                )
             )
-        )
-        resolver_keys.add(key)
+            resolver_keys.add(key)
 
     inline_output_keys = {
         ArtifactTypeKey(

--- a/libs/core/src/grafy_core/runtime/plugin_invocation.py
+++ b/libs/core/src/grafy_core/runtime/plugin_invocation.py
@@ -409,6 +409,12 @@ def _accepts_of(
     return artifact_type_bindings.get(variable, ArtifactTypeVariable(variable))
 
 
+def _also_accepts_of(port: PluginPortContract) -> tuple[ArtifactTypeKey, ...]:
+    return tuple(
+        ArtifactTypeKey(key.id, key.schema_version) for key in port.also_accepts
+    )
+
+
 def _input_model_for(
     contract: PluginNodeContract,
     artifact_type_bindings: Mapping[str, ArtifactTypeKey],
@@ -416,22 +422,25 @@ def _input_model_for(
     fields: dict[str, tuple[object, object]] = {}
     for port in contract.inputs:
         accepts = _accepts_of(port, artifact_type_bindings)
+        also_accepts = _also_accepts_of(port)
         description = port.description
         if port.instance_plugs:
             annotation = list[ArtifactRef | ArtifactRefSequence]
-            meta = InPort(accepts, variadic=True, instance_plugs=True)
+            meta = InPort(
+                accepts,
+                variadic=True,
+                instance_plugs=True,
+                also_accepts=also_accepts,
+            )
         elif port.variadic:
             item_annotation = (
                 ArtifactRefSequence if port.shape == "many" else ArtifactRef
             )
             annotation = list[item_annotation]  # type: ignore[valid-type]
-            meta = InPort(accepts, variadic=True)
-        elif port.shape == "many":
-            annotation = ArtifactRefSequence
-            meta = InPort(accepts)
+            meta = InPort(accepts, variadic=True, also_accepts=also_accepts)
         else:
-            annotation = ArtifactRef
-            meta = InPort(accepts)
+            annotation = ArtifactRefSequence if port.shape == "many" else ArtifactRef
+            meta = InPort(accepts, also_accepts=also_accepts)
         if port.required:
             fields[port.name] = (
                 Annotated[annotation, meta],  # type: ignore[valid-type]

--- a/tests/unit/core/test_invocation.py
+++ b/tests/unit/core/test_invocation.py
@@ -151,6 +151,13 @@ class CollectionInput(NodeInput):
     items: Annotated[list[int], InPort(INPUT_VALUE)]
 
 
+class MultiTypeInput(NodeInput):
+    source: Annotated[
+        ArtifactRef,
+        InPort(INPUT_VALUE, also_accepts=(OTHER_VALUE,)),
+    ]
+
+
 class CollectionOutput(NodeOutput):
     total: Annotated[int, OutPort(OUTPUT_VALUE)]
 
@@ -385,6 +392,35 @@ async def test_materializer_rejects_wrong_key_empty_sequence() -> None:
                     item_refs=[],
                 )
             },
+            TEST_WORKSPACE_ID,
+        )
+
+
+@pytest.mark.asyncio
+async def test_materializer_accepts_every_declared_artifact_type() -> None:
+    materializer = InputMaterializer(ResolverRegistry())
+    contract = derive_input_contract(MultiTypeInput)
+
+    for key in (INPUT_VALUE.key, OTHER_VALUE.key):
+        ref = ArtifactRef.from_key(artifact_id=uuid4(), key=key)
+        inputs, _ = await materializer.materialize(
+            contract,
+            {"source": ref},
+            TEST_WORKSPACE_ID,
+        )
+        assert inputs.source == ref
+
+    third = ArtifactRef.from_key(
+        artifact_id=uuid4(),
+        key=ArtifactTypeKey("test.third_value", 1),
+    )
+    with pytest.raises(
+        MaterializationError,
+        match="expected test.input_value@1, test.other_value@1, got test.third_value@1",
+    ):
+        await materializer.materialize(
+            contract,
+            {"source": third},
             TEST_WORKSPACE_ID,
         )
 

--- a/tests/unit/core/test_node_contracts.py
+++ b/tests/unit/core/test_node_contracts.py
@@ -1,8 +1,7 @@
 from typing import Annotated
 
 import pytest
-from pydantic import Field, ValidationError
-
+from grafy_core.artifact_contracts import RASTER_IMAGE, TEXT_VALUE
 from grafy_core.artifacts import (
     ArtifactRef,
     ArtifactRefSequence,
@@ -16,6 +15,7 @@ from grafy_core.nodes import (
     MAX_NODE_ERROR_MESSAGE_LENGTH,
     ArtifactTypeVariable,
     InPort,
+    InputPortSpec,
     Node,
     NodeContractError,
     NodeContractResolutionError,
@@ -26,7 +26,7 @@ from grafy_core.nodes import (
     derive_input_contract,
     resolve_node_contracts,
 )
-from grafy_core.artifact_contracts import RASTER_IMAGE
+from pydantic import Field, ValidationError
 
 
 class ExampleImage:
@@ -80,6 +80,13 @@ class InstancePlugInput(NodeInput):
     items: Annotated[
         list[ArtifactRef | ArtifactRefSequence],
         InPort(RASTER_IMAGE, variadic=True, instance_plugs=True),
+    ]
+
+
+class MultiTypeInput(NodeInput):
+    source: Annotated[
+        ExampleImage,
+        InPort(RASTER_IMAGE, also_accepts=(TEXT_VALUE,)),
     ]
 
 
@@ -176,6 +183,51 @@ def test_input_contract_supports_optional_variadic_and_structural_types() -> Non
     assert page_refs.shape is PortShape.MANY
     assert page_refs.target_type is None
     assert page_refs.preserves_ref_container is True
+
+
+def test_input_contract_derives_ordered_accepted_artifact_types() -> None:
+    port = derive_input_contract(MultiTypeInput).ports["source"]
+
+    assert port.accepts == RASTER_IMAGE.key
+    assert port.also_accepts == (TEXT_VALUE.key,)
+    assert port.accepted_types == (RASTER_IMAGE.key, TEXT_VALUE.key)
+
+
+def test_single_type_input_port_keeps_its_previous_contract() -> None:
+    port = derive_input_contract(AnnotationShapesInput).ports["page_refs"]
+
+    assert port.accepts == RASTER_IMAGE.key
+    assert port.also_accepts == ()
+    assert port.accepted_types == (RASTER_IMAGE.key,)
+
+
+def test_input_port_rejects_a_type_variable_with_additional_accepted_types() -> None:
+    with pytest.raises(
+        NodeContractError,
+        match="either an artifact type variable or additional accepted artifact types",
+    ):
+        InPort(ArtifactTypeVariable("T"), also_accepts=(TEXT_VALUE,))
+
+
+def test_input_port_rejects_repeating_its_primary_artifact_type() -> None:
+    with pytest.raises(NodeContractError, match="repeats its primary artifact type"):
+        InputPortSpec(
+            name="source",
+            accepts=RASTER_IMAGE.key,
+            also_accepts=(RASTER_IMAGE.key,),
+        )
+
+
+def test_input_port_rejects_duplicate_additional_accepted_types() -> None:
+    with pytest.raises(
+        NodeContractError,
+        match="duplicate additional accepted artifact types",
+    ):
+        InputPortSpec(
+            name="source",
+            accepts=RASTER_IMAGE.key,
+            also_accepts=(TEXT_VALUE.key, TEXT_VALUE.key),
+        )
 
 
 def test_input_contract_derives_mixed_instance_plug_shapes() -> None:

--- a/tests/unit/core/test_saved_graphs.py
+++ b/tests/unit/core/test_saved_graphs.py
@@ -16,7 +16,6 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphAnnotationLayout,
     SavedGraphArtifactTypeBinding,
     SavedGraphDocument,
-    SavedGraphConversion,
     SavedGraphEdge,
     SavedGraphInputPlug,
     SavedGraphNode,


### PR DESCRIPTION
Closes #29

## What changed

One input port can now declare an ordered set of accepted concrete artifact types. This is the contract prerequisite for `table.import@1` (csv + xlsx) and `image.decode@1` (five image containers), which a single `ArtifactTypeVariable` cannot express because a variable binds one concrete type per node instance.

- **Core** (`libs/core/src/grafy_core/nodes.py`): `InPort` and `InputPortSpec` gain `also_accepts` after the primary `accepts` type, exposed as the `accepted_types` property (primary first). It is mutually exclusive with a type variable, rejects a repeated/duplicate primary type, and is derived from the annotation.
- **Release contract** (`domain/plugin_releases.py`): `PluginPortContract` carries the same set and `from_input_port` fills it. Empty `also_accepts` is dropped from `plugin_contract_digest`, so existing release bytes and `tests/unit/architecture/system_plugin_catalog_identity.json` are unchanged; a node that uses the new field changes its digest on purpose and stays a collision if the id matches.
- **Validation** uses membership in the accepted set: graph compiler, in-process input materializer, MAP input check, guest binding check, plugin registration, and release admission all check every accepted type.
- **API** (`v1/routes/catalog/models.py`): `PortResponse` keeps `artifact_type` as the first accepted type and adds `also_accepts` for the rest, so single-type ports and their consumers do not change.
- **Web** (`canvas/handles.ts`, `canvas/types.ts`): `PortMeta` carries `alsoAccepts`; the target handle id encodes the extra types. `connectionRoutesFor`, `connectionIsValid`, `connectionArtifactContractIsValid`, `projectionCandidatesForConnection`, and persisted-route replay accept an edge when the source type matches any member, or reaches a member through a declared conversion.

## Tests

- `tests/unit/core/test_node_contracts.py`: two accepted types derive in order; a single-type port keeps `accepted_types == (primary,)`; type-variable + set, repeated primary, and duplicate types are rejected.
- `tests/unit/core/test_invocation.py`: the materializer accepts either declared type and refuses a third.
- `apps/web/.../handles.test.ts`: handle round-trip, accept either declared type, refuse a third, accept a declared conversion to a member, and drag validation against any member.

Verified: `pytest tests/unit` (1386 passed, 41 skipped), full web suite (621 passed), `npm run typecheck`, `npm run check:api`, and `basedpyright` on every changed file (only pre-existing errors remain in untouched code).

## Leftover risk

The isolated Plugin runtime protocol sends one `artifact_type` per input binding, so a multi-type input is not yet representable across that boundary. Builtin/in-process nodes (the consumers named in #29) work end to end; the isolated path needs a protocol change when a released Plugin node uses the field, which is naturally part of #30/#31.
