### PR TITLE
Give drawer-placed artifact cards a home in the saved graph document

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -554,6 +554,13 @@ revision, not fields inside the saved graph. Upstream output pins belong to an
 individual run request and remain transient. Drafts may be saved before they
 are executable.
 
+A presentation viewer may carry one artifact reference instead of a link to a
+node output. Such a viewer is a node-less artifact card: it presents that
+exact artifact and executes nothing. The reference is durable document state
+and is never dropped when the artifact is deleted, becomes inaccessible, or
+cannot cross a Workspace or Template boundary; the card stays and reports the
+reference as missing until the user removes the card deliberately.
+
 Saved graphs use optimistic revisions. Replacing a graph requires the revision
 last read by the caller so competing edits are reported instead of silently
 overwriting one another.

--- a/apps/api/src/grafy_api/graph_contracts.py
+++ b/apps/api/src/grafy_api/graph_contracts.py
@@ -11,6 +11,7 @@ from pydantic import (
     model_validator,
 )
 
+from grafy_core.artifacts import ArtifactRef
 from grafy_core.conversions import MAX_ARTIFACT_CONVERSION_HOPS
 from grafy_core.domain.collaboration import (
     CollaborativeGraphHead,
@@ -139,6 +140,7 @@ class GraphPresentationViewerModel(SavedGraphApiModel):
     position: GraphPointModel
     layout: SavedGraphNodeLayoutModel | None = None
     mode: str | None = Field(default=None, max_length=255)
+    artifact_ref: ArtifactRef | None = None
 
 
 class SavedGraphAnnotationLayoutModel(SavedGraphApiModel):

--- a/apps/web/openapi/grafy.json
+++ b/apps/web/openapi/grafy.json
@@ -2979,6 +2979,16 @@
       "GraphPresentationViewer": {
         "additionalProperties": false,
         "properties": {
+          "artifact_ref": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtifactRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "id": {
             "maxLength": 255,
             "minLength": 1,
@@ -3021,6 +3031,16 @@
       "GraphPresentationViewerModel": {
         "additionalProperties": false,
         "properties": {
+          "artifact_ref": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtifactRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "id": {
             "maxLength": 255,
             "minLength": 1,

--- a/apps/web/src/lib/api/generated/grafy.ts
+++ b/apps/web/src/lib/api/generated/grafy.ts
@@ -2190,6 +2190,7 @@ export interface components {
         };
         /** GraphPresentationViewer */
         readonly GraphPresentationViewer: {
+            readonly artifact_ref?: components["schemas"]["ArtifactRef"] | null;
             /** Id */
             readonly id: string;
             readonly layout?: components["schemas"]["SavedGraphNodeLayout"] | null;
@@ -2199,6 +2200,7 @@ export interface components {
         };
         /** GraphPresentationViewerModel */
         readonly GraphPresentationViewerModel: {
+            readonly artifact_ref?: components["schemas"]["ArtifactRef"] | null;
             /** Id */
             readonly id: string;
             readonly layout?: components["schemas"]["SavedGraphNodeLayoutModel"] | null;

--- a/libs/core/src/grafy_core/domain/saved_graphs.py
+++ b/libs/core/src/grafy_core/domain/saved_graphs.py
@@ -16,7 +16,7 @@ from pydantic import (
     model_validator,
 )
 
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.conversions import MAX_ARTIFACT_CONVERSION_HOPS
 from grafy_core.domain.errors import SavedGraphRevisionConflictError
 from grafy_core.domain.identity import WorkspaceKind
@@ -366,6 +366,10 @@ class GraphPresentationViewer(SavedGraphValue):
     position: GraphPoint
     layout: SavedGraphNodeLayout | None = None
     mode: str | None = Field(default=None, max_length=255)
+    # A node-less card: it presents one persisted artifact and executes nothing.
+    # The reference is kept even when the artifact is gone, so the card can show
+    # a missing state until the user removes it. It is never a link target.
+    artifact_ref: ArtifactRef | None = None
 
     @field_validator("id")
     @classmethod
@@ -512,6 +516,9 @@ class GraphPresentationDocument(SavedGraphValue):
         if len(viewer_ids) != len(set(viewer_ids)):
             raise ValueError("Presentation viewer ids must be unique")
         known_viewers = set(viewer_ids)
+        artifact_viewers = {
+            viewer.id for viewer in self.viewers if viewer.artifact_ref is not None
+        }
 
         link_ids = [link.id for link in self.links]
         if len(link_ids) != len(set(link_ids)):
@@ -521,6 +528,11 @@ class GraphPresentationDocument(SavedGraphValue):
             if link.target_viewer_id not in known_viewers:
                 raise ValueError(
                     f"Presentation link {link.id} references missing viewer "
+                    f"{link.target_viewer_id}"
+                )
+            if link.target_viewer_id in artifact_viewers:
+                raise ValueError(
+                    f"Presentation link {link.id} cannot target artifact card "
                     f"{link.target_viewer_id}"
                 )
             if link.target_viewer_id in linked_viewers:

--- a/tests/integration/executions/test_plugin_egress_docker.py
+++ b/tests/integration/executions/test_plugin_egress_docker.py
@@ -154,6 +154,8 @@ def _network_egress_plugin(repository: Path, destination: Path) -> Path:
 
 import urllib.request
 
+from grafy_core.artifact_contracts import TEXT_VALUE, TextValue
+from grafy_core.artifacts import NoConfig, NodeInput, NodeOutput
 from grafy_core.domain.plugin_capabilities import PluginRuntimeCapability
 
 

--- a/tests/integration/saved_graphs/test_saved_graphs.py
+++ b/tests/integration/saved_graphs/test_saved_graphs.py
@@ -19,9 +19,15 @@ from grafy_api.graph_contracts import (
     SubmitGraphCommandRequest,
     UpdateSavedGraphRequest,
 )
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.collaboration import RenameGraphCommand
 from grafy_core.domain.identity import ActorContext
-from grafy_core.domain.saved_graphs import SavedGraphDocument
+from grafy_core.domain.saved_graphs import (
+    GraphPoint,
+    GraphPresentationDocument,
+    GraphPresentationViewer,
+    SavedGraphDocument,
+)
 
 from tests.support.clients import GrafyApi
 from tests.support.identity import TEST_USER_ID, WORKSPACE_ID
@@ -218,6 +224,44 @@ def test_create_accepts_the_canonical_saved_graph_document(
     assert body["document"] == document
     assert "nodes" not in body
     assert "edges" not in body
+
+
+def test_saved_graph_round_trips_an_artifact_card(
+    builtin_client: TestClient,
+) -> None:
+    reference = ArtifactRef.from_key(
+        artifact_id=UUID("00000000-0000-0000-0000-0000000000cc"),
+        key=ArtifactTypeKey("table.data", 1),
+        content_hash="d" * 64,
+    )
+    document = _graph_document().with_topology(
+        presentation=GraphPresentationDocument(
+            viewers=(
+                GraphPresentationViewer(
+                    id="artifact-viewer-card",
+                    position=GraphPoint(x=12.0, y=34.0),
+                    artifact_ref=reference,
+                ),
+            ),
+        ),
+    )
+    api = GrafyApi(builtin_client)
+    graphs = api.workspace(WORKSPACE_ID).graphs
+
+    create_response = graphs.create(
+        CreateSavedGraphRequest(name="Artifact card", document=document)
+    )
+
+    assert create_response.status_code == 201
+    created = create_response.json()
+    assert created["document"]["presentation"]["viewers"][0]["artifact_ref"] == {
+        "artifact_id": "00000000-0000-0000-0000-0000000000cc",
+        "artifact_type": "table.data",
+        "schema_version": 1,
+        "content_hash": "d" * 64,
+    }
+    graph_id = UUID(created["id"])
+    assert graphs.get(graph_id).json()["document"] == created["document"]
 
 
 def test_saved_graph_crud_round_trip(builtin_client: TestClient) -> None:

--- a/tests/unit/api/test_graph_transport_conversion.py
+++ b/tests/unit/api/test_graph_transport_conversion.py
@@ -15,10 +15,13 @@ from grafy_api.graph_contracts import (
     SavedGraphNodeModel,
     SavedGraphNodeLayoutModel,
 )
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.collaboration import CollaborativeGraphHead
 from grafy_core.domain.saved_graphs import (
     SavedGraphDocument,
+    GraphPoint,
     GraphPresentationDocument,
+    GraphPresentationViewer,
     SavedGraphEdge,
     SavedGraphNode,
     SavedGraphNodeLayout,
@@ -301,3 +304,36 @@ def test_head_adapter_preserves_metadata_and_empty_document(head: CollaborativeG
     assert "schema_version" not in payload
     assert "workspace_id" not in payload
     assert CollaborativeHeadResponse.model_validate_json(legacy.model_dump_json()) == legacy
+
+
+def test_artifact_card_reference_survives_head_transport(
+    head: CollaborativeGraphHead,
+) -> None:
+    reference = ArtifactRef.from_key(
+        artifact_id=UUID(int=77),
+        key=ArtifactTypeKey("table.data", 1),
+        content_hash="b" * 64,
+    )
+    head.document = head.document.with_topology(
+        presentation=GraphPresentationDocument(
+            viewers=(
+                GraphPresentationViewer(
+                    id="artifact-viewer-card",
+                    position=GraphPoint(x=1.0, y=2.0),
+                    artifact_ref=reference,
+                ),
+            ),
+        ),
+    )
+
+    canonical = CanonicalCollaborativeHeadResponse.from_head(head)
+    legacy = CollaborativeHeadResponse.from_head(head)
+
+    assert canonical.document.presentation.viewers[0].artifact_ref == reference
+    assert legacy.presentation.viewers[0].artifact_ref == reference
+    assert (
+        legacy.model_dump(mode="json")["presentation"]["viewers"][0][
+            "artifact_ref"
+        ]["artifact_type"]
+        == "table.data"
+    )

--- a/tests/unit/core/test_collaboration.py
+++ b/tests/unit/core/test_collaboration.py
@@ -3,7 +3,7 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic import ValidationError
 
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.collaboration import (
     AddEdgeCommand,
     AddNodeCommand,
@@ -496,6 +496,30 @@ def test_add_edge_and_sanitize_copy_document() -> None:
     with pytest.raises(CollaborationCommandRejectedError) as exc:
         sanitize_document_for_cross_workspace_copy(module_document)
     assert exc.value.error_code == "foreign_module_reference"
+
+
+def test_cross_workspace_copy_keeps_an_unsatisfied_artifact_card_reference() -> (
+    None
+):
+    reference = ArtifactRef.from_key(
+        artifact_id=uuid4(),
+        key=ArtifactTypeKey("table.data", 1),
+    )
+    document = SavedGraphDocument(
+        presentation=GraphPresentationDocument(
+            viewers=(
+                GraphPresentationViewer(
+                    id="artifact-viewer-card",
+                    position=GraphPoint(x=1, y=2),
+                    artifact_ref=reference,
+                ),
+            ),
+        ),
+    )
+
+    copied = sanitize_document_for_cross_workspace_copy(document)
+
+    assert copied.presentation.viewers[0].artifact_ref == reference
 
 
 def test_cross_workspace_copy_preserves_system_pins_and_rejects_workspace_pins() -> (

--- a/tests/unit/core/test_saved_graphs.py
+++ b/tests/unit/core/test_saved_graphs.py
@@ -5,18 +5,19 @@ from uuid import UUID
 import pytest
 from pydantic import ValidationError
 
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.errors import SavedGraphRevisionConflictError
 from grafy_core.domain.plugin_releases import PluginReleaseScope
 from grafy_core.domain.saved_graphs import (
     GraphPoint,
     GraphPresentationAnnotation,
     GraphPresentationDocument,
+    GraphPresentationLink,
+    GraphPresentationViewer,
     SavedGraph,
     SavedGraphAnnotationLayout,
     SavedGraphArtifactTypeBinding,
     SavedGraphDocument,
-    SavedGraphConversion,
     SavedGraphEdge,
     SavedGraphInputPlug,
     SavedGraphNode,
@@ -212,6 +213,119 @@ def test_presentation_annotations_round_trip_and_reject_shape_text() -> None:
             position=GraphPoint(x=0.0, y=0.0),
             layout=SavedGraphAnnotationLayout(width=80, height=80),
             color="red",
+        )
+
+
+ARTIFACT_CARD_REF = ArtifactRef.from_key(
+    artifact_id=UUID("00000000-0000-0000-0000-0000000000aa"),
+    key=ArtifactTypeKey("table.data", 1),
+    content_hash="a" * 64,
+)
+
+
+def test_artifact_card_reference_round_trips_without_a_link() -> None:
+    document = SavedGraphDocument(
+        presentation=GraphPresentationDocument(
+            viewers=(
+                GraphPresentationViewer(
+                    id="artifact-viewer-card",
+                    position=GraphPoint(x=4.0, y=8.0),
+                    layout=SavedGraphNodeLayout(width=320, body_height=240),
+                    artifact_ref=ARTIFACT_CARD_REF,
+                ),
+            ),
+        ),
+    )
+
+    payload = document.model_dump(mode="json")
+
+    assert payload["schema_version"] == 6
+    assert payload["presentation"]["viewers"][0]["artifact_ref"] == {
+        "artifact_id": "00000000-0000-0000-0000-0000000000aa",
+        "artifact_type": "table.data",
+        "schema_version": 1,
+        "content_hash": "a" * 64,
+    }
+    assert SavedGraphDocument.model_validate(payload) == document
+
+
+def test_artifact_card_keeps_its_reference_when_the_artifact_is_missing() -> None:
+    # Loading a document never consults the artifact store, so a deleted or
+    # inaccessible artifact leaves the stored reference untouched.
+    document = SavedGraphDocument.model_validate(
+        {
+            "schema_version": 6,
+            "nodes": [],
+            "edges": [],
+            "presentation": {
+                "viewers": [
+                    {
+                        "id": "artifact-viewer-card",
+                        "position": {"x": 0.0, "y": 0.0},
+                        "artifact_ref": {
+                            "artifact_id": "00000000-0000-0000-0000-00000000dead",
+                            "artifact_type": "table.data",
+                            "schema_version": 1,
+                        },
+                    }
+                ]
+            },
+        }
+    )
+
+    card = document.presentation.viewers[0]
+    assert card.artifact_ref is not None
+    assert card.artifact_ref.artifact_id == UUID(
+        "00000000-0000-0000-0000-00000000dead"
+    )
+    reloaded = SavedGraphDocument.model_validate(document.model_dump(mode="json"))
+    assert reloaded.presentation.viewers[0].artifact_ref == card.artifact_ref
+
+
+def test_presentation_viewer_without_artifact_reference_reads_as_unset() -> None:
+    document = SavedGraphDocument.model_validate(
+        {
+            "schema_version": 6,
+            "nodes": [],
+            "edges": [],
+            "presentation": {
+                "viewers": [
+                    {
+                        "id": "artifact-viewer-node-output",
+                        "position": {"x": 1.0, "y": 2.0},
+                    }
+                ]
+            },
+        }
+    )
+
+    assert document.presentation.viewers[0].artifact_ref is None
+    assert (
+        document.model_dump(mode="json")["presentation"]["viewers"][0][
+            "artifact_ref"
+        ]
+        is None
+    )
+
+
+def test_artifact_card_cannot_be_a_presentation_link_target() -> None:
+    with pytest.raises(ValidationError, match="cannot target artifact card"):
+        GraphPresentationDocument(
+            viewers=(
+                GraphPresentationViewer(
+                    id="artifact-viewer-card",
+                    position=GraphPoint(x=0.0, y=0.0),
+                    artifact_ref=ARTIFACT_CARD_REF,
+                ),
+            ),
+            links=(
+                GraphPresentationLink(
+                    id="artifact-viewer-edge-1",
+                    source_node_id="source",
+                    source_port_name="result",
+                    target_viewer_id="artifact-viewer-card",
+                ),
+            ),
         )
 
 

--- a/tests/unit/persistence/test_saved_graph_persistence.py
+++ b/tests/unit/persistence/test_saved_graph_persistence.py
@@ -8,12 +8,14 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.errors import ConcurrentWriteError
 from grafy_core.domain.saved_graphs import (
     GraphFolder,
     GraphOrganization,
     GraphPoint,
+    GraphPresentationDocument,
+    GraphPresentationViewer,
     SavedGraph,
     SavedGraphArtifactTypeBinding,
     SavedGraphConversion,
@@ -244,6 +246,46 @@ async def test_file_backed_sqlite_round_trips_saved_graph_in_a_fresh_session(
     assert loaded.updated_at == graph.updated_at
     assert loaded.created_at.tzinfo is UTC
     assert loaded.updated_at.tzinfo is UTC
+
+
+@pytest.mark.asyncio
+async def test_file_backed_sqlite_round_trips_an_artifact_card_reference(
+    database: Database,
+) -> None:
+    reference = ArtifactRef.from_key(
+        artifact_id=UUID("00000000-0000-0000-0000-0000000000bb"),
+        key=ArtifactTypeKey("table.data", 1),
+        content_hash="c" * 64,
+    )
+    graph = SavedGraph(
+        workspace_id=WORKSPACE_ID,
+        id=UUID("00000000-0000-0000-0000-000000000103"),
+        name="Card graph",
+        document=SavedGraphDocument(
+            presentation=GraphPresentationDocument(
+                viewers=(
+                    GraphPresentationViewer(
+                        id="artifact-viewer-card",
+                        position=GraphPoint(x=5.0, y=6.0),
+                        artifact_ref=reference,
+                    ),
+                ),
+            ),
+        ),
+        created_at=datetime(2026, 7, 14, 8, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 7, 14, 8, 30, tzinfo=UTC),
+    )
+
+    async with SqlAlchemySavedGraphUnitOfWork(database.sessions) as unit_of_work:
+        await unit_of_work.graphs.add(graph)
+        await unit_of_work.commit()
+
+    async with SqlAlchemySavedGraphUnitOfWork(database.sessions) as unit_of_work:
+        loaded = await unit_of_work.graphs.get(WORKSPACE_ID, graph.id)
+
+    assert loaded is not None
+    assert loaded.document.presentation.viewers[0].artifact_ref == reference
+    assert loaded.document.schema_version == 6
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #36.

Adds an optional `artifact_ref` to presentation viewers in the canonical saved graph and API mirror. A viewer with a reference stores an exact persisted artifact without a source node. Presentation links cannot target these cards.

The canvas adapter preserves the reference through load and save. Loading does not consult artifact storage, and cross-workspace copies retain the reference as unsatisfied. Card rendering and drawer interactions are follow-up UI work.

## Schema

Uses schema 7, introduced by origins in #54. The optional field is additive; existing viewers read it as unset. Schema-6 migration coverage remains.

## Validation

- 125 focused backend tests passed, covering document validation, collaboration, transport, and SQLite persistence.
- 22 saved-graph HTTP integration tests passed.
- 636 web tests passed, including the artifact-card canvas round trip.
- TypeScript checking and Python lint passed.
- OpenAPI and TypeScript contracts regenerated.
