### PR TITLE
fix(graphs): one authoritative graph summary for every discovery surface

### DIFF
--- a/apps/api/src/grafy_api/graph_contracts.py
+++ b/apps/api/src/grafy_api/graph_contracts.py
@@ -233,23 +233,48 @@ class SavedGraphResponse(SavedGraphApiModel):
         )
 
 
+def graph_browser_updated_at(item: GraphBrowserItem) -> datetime:
+    """Freshness shared by every graph discovery surface for one graph."""
+
+    updated_at = item.draft.updated_at
+    if (
+        item.organization_updated_at is not None
+        and item.organization_updated_at > updated_at
+    ):
+        return item.organization_updated_at
+    return updated_at
+
+
 class SavedGraphSummaryResponse(SavedGraphApiModel):
+    """Authoritative summary shared by every graph discovery surface.
+
+    Counts and ``updated_at`` describe the collaborative draft head (what the
+    canvas shows). ``revision`` is the durable checkpoint revision used by
+    lifecycle writes, and ``draft_pending`` labels a head that is ahead of that
+    checkpoint.
+    """
+
     id: UUID
     name: str
     revision: int
     node_count: int
     edge_count: int
     updated_at: datetime
+    draft_pending: bool
 
     @classmethod
-    def from_graph(cls, graph: SavedGraph) -> "SavedGraphSummaryResponse":
+    def from_browser_item(
+        cls,
+        item: GraphBrowserItem,
+    ) -> "SavedGraphSummaryResponse":
         return cls(
-            id=graph.id,
-            name=graph.name,
-            revision=graph.revision,
-            node_count=len(graph.document.nodes),
-            edge_count=len(graph.document.edges),
-            updated_at=graph.updated_at,
+            id=item.id,
+            name=item.draft.name,
+            revision=item.draft.checkpoint_revision,
+            node_count=item.draft.node_count,
+            edge_count=item.draft.edge_count,
+            updated_at=graph_browser_updated_at(item),
+            draft_pending=item.draft.head_sequence > item.draft.checkpoint_sequence,
         )
 
 
@@ -257,12 +282,9 @@ class SavedGraphListResponse(SavedGraphApiModel):
     graphs: list[SavedGraphSummaryResponse]
 
     @classmethod
-    def from_graphs(
-        cls,
-        graphs: list[SavedGraph],
-    ) -> "SavedGraphListResponse":
+    def from_items(cls, items: list[GraphBrowserItem]) -> "SavedGraphListResponse":
         return cls(
-            graphs=[SavedGraphSummaryResponse.from_graph(graph) for graph in graphs]
+            graphs=[SavedGraphSummaryResponse.from_browser_item(item) for item in items]
         )
 
 
@@ -379,12 +401,6 @@ class GraphBrowserItemResponse(SavedGraphApiModel):
 
     @classmethod
     def from_item(cls, item: GraphBrowserItem) -> "GraphBrowserItemResponse":
-        updated_at = item.draft.updated_at
-        if (
-            item.organization_updated_at is not None
-            and item.organization_updated_at > updated_at
-        ):
-            updated_at = item.organization_updated_at
         return cls(
             id=item.id,
             location=GraphBrowserLocationResponse(
@@ -405,7 +421,7 @@ class GraphBrowserItemResponse(SavedGraphApiModel):
             archived_at=item.archived_at,
             starred=item.starred,
             last_opened_at=item.last_opened_at,
-            updated_at=updated_at,
+            updated_at=graph_browser_updated_at(item),
             draft=GraphBrowserDraftResponse(
                 name=item.draft.name,
                 head_sequence=item.draft.head_sequence,

--- a/apps/api/src/grafy_api/v1/routes/saved_graphs/views.py
+++ b/apps/api/src/grafy_api/v1/routes/saved_graphs/views.py
@@ -142,8 +142,11 @@ async def list_saved_graphs(
     service: SavedGraphDependency,
     access: require_workspace_capability(WorkspaceCapability.VIEW_GRAPH),
 ) -> SavedGraphListResponse:
-    graphs = await service.list(access.workspace_id)
-    return SavedGraphListResponse.from_graphs(graphs)
+    items = await service.list_accessible(
+        access.actor,
+        workspace_id=access.workspace_id,
+    )
+    return SavedGraphListResponse.from_items(items)
 
 
 @router.put("/{graph_id}/folder", response_model=GraphOrganizationResponse)

--- a/apps/web/openapi/grafy.json
+++ b/apps/web/openapi/grafy.json
@@ -5826,7 +5826,12 @@
       },
       "SavedGraphSummaryResponse": {
         "additionalProperties": false,
+        "description": "Authoritative summary shared by every graph discovery surface.\n\nCounts and ``updated_at`` describe the collaborative draft head (what the\ncanvas shows). ``revision`` is the durable checkpoint revision used by\nlifecycle writes, and ``draft_pending`` labels a head that is ahead of that\ncheckpoint.",
         "properties": {
+          "draft_pending": {
+            "title": "Draft Pending",
+            "type": "boolean"
+          },
           "edge_count": {
             "title": "Edge Count",
             "type": "integer"
@@ -5860,7 +5865,8 @@
           "revision",
           "node_count",
           "edge_count",
-          "updated_at"
+          "updated_at",
+          "draft_pending"
         ],
         "title": "SavedGraphSummaryResponse",
         "type": "object"

--- a/apps/web/src/features/graphs/GraphBrowser.tsx
+++ b/apps/web/src/features/graphs/GraphBrowser.tsx
@@ -27,7 +27,7 @@ import {
   WorkspaceRail,
   workspaceDisplayName,
 } from "@/features/workspaces/WorkspaceLayout";
-import { graphAgeLabel } from "@/features/workspaces/WorkspaceGraphPanel";
+import { graphAgeLabel, graphCountLabel } from "@/features/workspaces/WorkspaceGraphPanel";
 import {
   NEW_GRAPH_ROUTE_ID,
   workbenchGraphPath,
@@ -60,10 +60,7 @@ function GraphRow({ graph }: { graph: LocatedGraph }) {
         <span className="grafy-graphs__row-meta">
           {graphAgeLabel(graph.updated_at)}
         </span>
-        <span className="grafy-graphs__row-meta">
-          {graph.node_count} {graph.node_count === 1 ? "node" : "nodes"} ·{" "}
-          {graph.edge_count} {graph.edge_count === 1 ? "edge" : "edges"}
-        </span>
+        <span className="grafy-graphs__row-meta">{graphCountLabel(graph)}</span>
         <ArrowUpRight
           className="grafy-graphs__row-arrow"
           size={15}
@@ -223,6 +220,7 @@ export function GraphBrowser() {
             <span className="grafy-graphs__count">
               {filteredGraphs.length}{" "}
               {filteredGraphs.length === 1 ? "graph" : "graphs"}
+              {graphState.isRefreshing ? " · refreshing…" : ""}
             </span>
           ) : null}
         </div>

--- a/apps/web/src/features/graphs/WorkspaceGraphBrowser.test.tsx
+++ b/apps/web/src/features/graphs/WorkspaceGraphBrowser.test.tsx
@@ -67,6 +67,7 @@ function graph(
     edge_count: 2,
     revision: 4,
     updated_at: updatedAt,
+    draft_pending: false,
   };
 }
 

--- a/apps/web/src/features/graphs/WorkspaceGraphBrowser.tsx
+++ b/apps/web/src/features/graphs/WorkspaceGraphBrowser.tsx
@@ -20,6 +20,7 @@ import {
 import {
   filterGraphsByQuery,
   graphAgeLabel,
+  graphCountLabel,
   sortGraphsByRecency,
 } from "@/features/workspaces/WorkspaceGraphPanel";
 import {
@@ -57,10 +58,7 @@ function GraphRow({
         <span className="grafy-graphs__row-meta">
           {graphAgeLabel(graph.updated_at)}
         </span>
-        <span className="grafy-graphs__row-meta">
-          {graph.node_count} {graph.node_count === 1 ? "node" : "nodes"} ·{" "}
-          {graph.edge_count} {graph.edge_count === 1 ? "edge" : "edges"}
-        </span>
+        <span className="grafy-graphs__row-meta">{graphCountLabel(graph)}</span>
         <ArrowUpRight
           className="grafy-graphs__row-arrow"
           size={15}

--- a/apps/web/src/features/workbench/ui/SavedGraphBrowser.tsx
+++ b/apps/web/src/features/workbench/ui/SavedGraphBrowser.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 
+import { graphCountLabel } from "@/features/workspaces/WorkspaceGraphPanel";
 import type { SavedGraphSummary } from "@/lib/api";
 import { tokens } from "@/lib/stylex/tokens.stylex";
 
@@ -284,7 +285,7 @@ export function SavedGraphBrowser({
                   <span {...stylex.props(s.copy)}>
                     <span {...stylex.props(s.name)}>{graph.name}</span>
                     <span {...stylex.props(s.meta)}>
-                      {graph.node_count} nodes · {graph.edge_count} connections · r{graph.revision}
+                      {graphCountLabel(graph)} · r{graph.revision}
                     </span>
                   </span>
                 </button>

--- a/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.test.ts
+++ b/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.test.ts
@@ -25,6 +25,8 @@ const savedGraphQuery = vi.hoisted(() => ({
   mutate: vi.fn(),
 }));
 
+const graphSummaryRefresh = vi.hoisted(() => vi.fn());
+
 const api = vi.hoisted(() => ({
   createSavedGraph: vi.fn(),
   deleteSavedGraph: vi.fn(),
@@ -45,6 +47,7 @@ vi.mock("@/hooks/use-api", () => ({
     isValidating: false,
     mutate: savedGraphQuery.mutate,
   }),
+  useGraphSummaryRefresh: () => graphSummaryRefresh,
 }));
 
 vi.mock("@/lib/api", () => api);
@@ -92,6 +95,7 @@ function savedGraphSummary(graph: SavedGraph): SavedGraphSummary {
     node_count: graph.document.nodes.length,
     edge_count: graph.document.edges.length,
     updated_at: graph.updated_at,
+    draft_pending: false,
   };
 }
 
@@ -717,7 +721,7 @@ describe("useSavedGraphLifecycle document ownership", () => {
     expect(hook.result.current.activeGraph?.id).toBe(GRAPH_B_ID);
     expect(hook.result.current.graphName).toBe("Graph B");
     expect(router.replace).not.toHaveBeenCalled();
-    expect(savedGraphQuery.mutate).toHaveBeenCalledOnce();
+    expect(graphSummaryRefresh).toHaveBeenCalledWith(options.workspaceId);
     expect(options.refreshNodeRegistry).toHaveBeenCalledOnce();
   });
 
@@ -756,7 +760,7 @@ describe("useSavedGraphLifecycle document ownership", () => {
     expect(callbacks.replaceDocument).toHaveBeenCalledTimes(
       canvasReplacementCount,
     );
-    expect(savedGraphQuery.mutate).toHaveBeenCalledOnce();
+    expect(graphSummaryRefresh).toHaveBeenCalledWith(options.workspaceId);
     expect(callbacks.refreshNodeRegistry).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.ts
+++ b/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.ts
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 
-import { useSavedGraphs } from "@/hooks/use-api";
+import { useGraphSummaryRefresh, useSavedGraphs } from "@/hooks/use-api";
 import {
   createSavedGraph,
   deleteSavedGraph,
@@ -161,8 +161,10 @@ export function useSavedGraphLifecycle({
     error: savedGraphListError,
     isLoading: savedGraphsLoading,
     isValidating: savedGraphsRefreshing,
-    mutate: mutateSavedGraphs,
   } = useSavedGraphs(workspaceId);
+  // Saving, deleting, and room rehydration must refresh every discovery
+  // surface, not just this workspace's saved-graph list.
+  const refreshGraphSummaries = useGraphSummaryRefresh();
   const [activeGraph, setActiveGraph] =
     React.useState<ActiveSavedGraph | null>(null);
   const [savedFingerprint, setSavedFingerprint] =
@@ -377,7 +379,7 @@ export function useSavedGraphLifecycle({
               : await createSavedGraph(workspaceId, submittedDraft),
           };
       if (!mountedRef.current) return;
-      void mutateSavedGraphs();
+      void refreshGraphSummaries(workspaceId);
       void refreshNodeRegistry();
       if (
         documentGenerationRef.current !== documentGeneration
@@ -457,9 +459,9 @@ export function useSavedGraphLifecycle({
     currentDraft,
     deletingGraphId,
     isExecutionRunning,
-    mutateSavedGraphs,
     nodes,
     openingGraphId,
+    refreshGraphSummaries,
     refreshNodeRegistry,
     refreshNodeSecretStatuses,
     rememberSavedDraft,
@@ -731,7 +733,7 @@ export function useSavedGraphLifecycle({
     try {
       await deleteSavedGraph(workspaceId, graph.id, expectedRevision);
       if (!mountedRef.current) return;
-      void mutateSavedGraphs();
+      void refreshGraphSummaries(workspaceId);
       void refreshNodeRegistry();
       if (
         documentGenerationRef.current !== documentGeneration
@@ -785,7 +787,7 @@ export function useSavedGraphLifecycle({
     clearGraphSecretStatuses,
     currentFingerprint,
     isDirty,
-    mutateSavedGraphs,
+    refreshGraphSummaries,
     refreshNodeRegistry,
     router,
     showBlankGraph,
@@ -811,8 +813,8 @@ export function useSavedGraphLifecycle({
     setGraphBrowserOpen(false);
   }, []);
   const refreshSavedGraphs = React.useCallback(() => {
-    void mutateSavedGraphs();
-  }, [mutateSavedGraphs]);
+    void refreshGraphSummaries(workspaceId);
+  }, [refreshGraphSummaries, workspaceId]);
   const savedGraphsError = savedGraphListError instanceof Error
     ? savedGraphListError.message
     : savedGraphListError

--- a/apps/web/src/features/workspaces/WorkspaceGraphPanel.test.ts
+++ b/apps/web/src/features/workspaces/WorkspaceGraphPanel.test.ts
@@ -10,6 +10,7 @@ import {
   WorkspaceGraphPanel,
   filterGraphsByQuery,
   graphAgeLabel,
+  graphCountLabel,
   sortGraphsByRecency,
 } from "./WorkspaceGraphPanel";
 
@@ -23,21 +24,26 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: testState.push }),
 }));
 
+const panelState = vi.hoisted(() => ({
+  graphs: [
+    {
+      id: "graph-invoice",
+      name: "Invoice intake",
+      node_count: 2,
+      edge_count: 1,
+      revision: 1,
+      updated_at: "2026-08-10T12:00:00Z",
+      draft_pending: false,
+    },
+  ],
+  isValidating: false,
+}));
+
 vi.mock("@/hooks/use-api", () => ({
   useSavedGraphs: () => ({
-    data: {
-      graphs: [
-        {
-          id: "graph-invoice",
-          name: "Invoice intake",
-          node_count: 2,
-          edge_count: 1,
-          revision: 1,
-          updated_at: "2026-08-10T12:00:00Z",
-        },
-      ],
-    },
+    data: { graphs: panelState.graphs },
     isLoading: false,
+    isValidating: panelState.isValidating,
   }),
 }));
 
@@ -55,6 +61,18 @@ afterEach(async () => {
   document.body.replaceChildren();
   vi.unstubAllGlobals();
   testState.push.mockReset();
+  panelState.graphs = [
+    {
+      id: "graph-invoice",
+      name: "Invoice intake",
+      node_count: 2,
+      edge_count: 1,
+      revision: 1,
+      updated_at: "2026-08-10T12:00:00Z",
+      draft_pending: false,
+    },
+  ];
+  panelState.isValidating = false;
 });
 
 const graph = (
@@ -68,6 +86,7 @@ const graph = (
   edge_count: 1,
   revision: 1,
   updated_at: updatedAt,
+  draft_pending: false,
   ...overrides,
 });
 
@@ -105,6 +124,21 @@ describe("workspace graph panel listing", () => {
     expect(graphAgeLabel("2026-08-10T11:15:00Z", now)).toBe("45m ago");
     expect(graphAgeLabel("2026-08-10T09:00:00Z", now)).toBe("3h ago");
     expect(graphAgeLabel("2026-08-06T12:00:00Z", now)).toBe("4d ago");
+  });
+
+  it("labels every graph summary with the same node and edge wording", () => {
+    expect(graphCountLabel({ node_count: 1, edge_count: 0 })).toBe(
+      "1 node · 0 edges",
+    );
+    expect(graphCountLabel({ node_count: 2, edge_count: 1 })).toBe(
+      "2 nodes · 1 edge",
+    );
+  });
+
+  it("labels a draft head that is ahead of the saved checkpoint", () => {
+    expect(
+      graphCountLabel({ node_count: 0, edge_count: 0, draft_pending: true }),
+    ).toBe("0 nodes · 0 edges · unsaved draft");
   });
 });
 
@@ -164,6 +198,34 @@ describe("workspace graph panel interactions", () => {
     accountMenu.dispatchEvent(new Event("pointerdown", { bubbles: true }));
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows a refreshing indicator instead of a confidently stale count", async () => {
+    panelState.isValidating = true;
+    const { container } = await renderPanel();
+
+    const status = container.querySelector("[role='status']");
+
+    expect(status?.textContent).toBe("Refreshing…");
+  });
+
+  it("labels a graph whose live draft is ahead of its saved checkpoint", async () => {
+    panelState.graphs = [
+      {
+        id: "graph-draft",
+        name: "Draft ahead",
+        node_count: 0,
+        edge_count: 0,
+        revision: 1,
+        updated_at: "2026-08-10T12:00:00Z",
+        draft_pending: true,
+      },
+    ];
+    const { container } = await renderPanel();
+
+    expect(
+      container.querySelector(".grafy-graph-panel__row-meta")?.textContent,
+    ).toContain("0 nodes · 0 edges · unsaved draft");
   });
 
   it("reports an explicit close", async () => {

--- a/apps/web/src/features/workspaces/WorkspaceGraphPanel.tsx
+++ b/apps/web/src/features/workspaces/WorkspaceGraphPanel.tsx
@@ -48,6 +48,23 @@ export function graphAgeLabel(updatedAt: string, now = Date.now()): string {
   return new Date(updatedAt).toLocaleDateString();
 }
 
+/**
+ * The one node/edge summary line every graph discovery surface renders.
+ *
+ * Counts describe the collaborative draft head, so a head that is ahead of the
+ * saved checkpoint is labelled instead of being presented as saved metadata.
+ */
+export function graphCountLabel(graph: {
+  node_count: number;
+  edge_count: number;
+  draft_pending?: boolean;
+}): string {
+  const nodes = `${graph.node_count} ${graph.node_count === 1 ? "node" : "nodes"}`;
+  const edges = `${graph.edge_count} ${graph.edge_count === 1 ? "edge" : "edges"}`;
+  const summary = `${nodes} · ${edges}`;
+  return graph.draft_pending ? `${summary} · unsaved draft` : summary;
+}
+
 export function WorkspaceGraphPanel({
   workspaceId,
   workspaceSlug,
@@ -66,7 +83,8 @@ export function WorkspaceGraphPanel({
   onClose: (reason: WorkspaceGraphPanelCloseReason) => void;
 }) {
   const router = useRouter();
-  const { data, isLoading } = useSavedGraphs(workspaceId);
+  const { data, isLoading, isValidating } = useSavedGraphs(workspaceId);
+  const isRefreshing = isValidating && Boolean(data);
   const finePointer = useMediaQuery(FINE_POINTER_QUERY);
   const [query, setQuery] = React.useState("");
   const panelRef = React.useRef<HTMLDivElement | null>(null);
@@ -130,6 +148,15 @@ export function WorkspaceGraphPanel({
           {total > 0 ? (
             <span className="grafy-graph-panel__count">{total}</span>
           ) : null}
+          {isRefreshing ? (
+            <span
+              className="grafy-graph-panel__count"
+              role="status"
+              aria-live="polite"
+            >
+              Refreshing…
+            </span>
+          ) : null}
         </p>
         <button
           type="button"
@@ -175,9 +202,7 @@ export function WorkspaceGraphPanel({
               >
                 <span className="grafy-graph-panel__row-name">{graph.name}</span>
                 <span className="grafy-graph-panel__row-meta">
-                  {`${graphAgeLabel(graph.updated_at)} · ${graph.node_count} ${
-                    graph.node_count === 1 ? "node" : "nodes"
-                  }`}
+                  {`${graphAgeLabel(graph.updated_at)} · ${graphCountLabel(graph)}`}
                 </span>
               </button>
               <GraphRowMenu

--- a/apps/web/src/features/workspaces/WorkspaceLayout.test.ts
+++ b/apps/web/src/features/workspaces/WorkspaceLayout.test.ts
@@ -85,6 +85,7 @@ vi.mock("@/hooks/use-api", () => ({
     data: { graphs: testState.savedGraphs },
     mutate: vi.fn(),
   }),
+  useGraphSummaryRefresh: () => vi.fn(),
   useWorkspaces: () => ({ data: [] }),
   useMyWorkspaceInvitations: () => ({ data: [], mutate: vi.fn() }),
 }));

--- a/apps/web/src/features/workspaces/WorkspaceLayout.tsx
+++ b/apps/web/src/features/workspaces/WorkspaceLayout.tsx
@@ -37,6 +37,7 @@ import {
   workbenchGraphPath,
 } from "@/features/workbench/routes";
 import {
+  useGraphSummaryRefresh,
   useMyWorkspaceInvitations,
   useSavedGraphs,
   useWorkspaces,
@@ -597,9 +598,10 @@ export function WorkspaceRail({
     selectedWorkspace,
   );
   const activeGraphId = workspaceRouteGraphId(pathname);
-  const { data: savedGraphs, mutate: mutateGraphs } = useSavedGraphs(
+  const { data: savedGraphs } = useSavedGraphs(
     activeWorkspace?.id,
   );
+  const refreshGraphSummaries = useGraphSummaryRefresh();
   const recentGraphs = React.useMemo(
     () =>
       sortGraphsByRecency(savedGraphs?.graphs ?? []).slice(
@@ -621,7 +623,7 @@ export function WorkspaceRail({
         } else {
           await renameSavedGraphRemote(activeWorkspace.id, graph, next);
         }
-        void mutateGraphs();
+        void refreshGraphSummaries(activeWorkspace.id);
       } catch (error) {
         window.alert(
           error instanceof Error
@@ -632,7 +634,7 @@ export function WorkspaceRail({
         setGraphActionBusyId(null);
       }
     },
-    [activeWorkspace, chrome, mutateGraphs],
+    [activeWorkspace, chrome, refreshGraphSummaries],
   );
 
   const deleteGraph = React.useCallback(
@@ -649,7 +651,7 @@ export function WorkspaceRail({
           );
           if (!deleted) return;
         }
-        void mutateGraphs();
+        void refreshGraphSummaries(activeWorkspace.id);
       } catch (error) {
         window.alert(
           error instanceof Error
@@ -660,7 +662,7 @@ export function WorkspaceRail({
         setGraphActionBusyId(null);
       }
     },
-    [activeWorkspace, chrome, mutateGraphs],
+    [activeWorkspace, chrome, refreshGraphSummaries],
   );
 
   return (

--- a/apps/web/src/hooks/use-api.test.tsx
+++ b/apps/web/src/hooks/use-api.test.tsx
@@ -26,8 +26,11 @@ vi.mock("@/lib/api/client", () => ({
 }));
 
 import {
+  ALL_GRAPHS_KEY,
   type AllWorkspacesGraphsResult,
+  revalidateGraphSummaries,
   useAllWorkspacesGraphs,
+  workspaceGraphsKey,
 } from "./use-api";
 
 const personal: Workspace = {
@@ -58,6 +61,57 @@ function Harness({ workspaces }: { workspaces: readonly Workspace[] }) {
   const value = useAllWorkspacesGraphs(workspaces);
   React.useEffect(() => captureLatest(value), [value]);
   return <span>{value.graphs?.length ?? "loading"}</span>;
+}
+
+function browserGraph(
+  id: string,
+  sequence: { head_sequence: number; checkpoint_sequence: number },
+) {
+  return {
+    id,
+    location: {
+      id: personal.id,
+      slug: personal.slug,
+      name: personal.name,
+      kind: personal.kind,
+    },
+    folder: null,
+    archived: false,
+    archived_at: null,
+    starred: false,
+    last_opened_at: null,
+    updated_at: "2026-08-10T12:00:00Z",
+    draft: {
+      name: id,
+      checkpoint_revision: 1,
+      updated_at: "2026-08-10T12:00:00Z",
+      node_count: 2,
+      edge_count: 1,
+      ...sequence,
+    },
+    creator: null,
+  };
+}
+
+async function renderGraphs(workspaces: readonly Workspace[]) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <Harness workspaces={workspaces} />
+      </SWRConfig>,
+    );
+  });
+  await vi.waitFor(() => expect(latest?.graphs).not.toBeNull());
+  return root;
 }
 
 beforeEach(() => {
@@ -154,5 +208,59 @@ describe("useAllWorkspacesGraphs", () => {
     expect(apiMocks.request).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
+  });
+
+  it("labels a draft head that is ahead of the saved checkpoint", async () => {
+    apiMocks.request.mockResolvedValue({
+      graphs: [
+        browserGraph("graph-pending", {
+          head_sequence: 4,
+          checkpoint_sequence: 3,
+        }),
+        browserGraph("graph-checkpointed", {
+          head_sequence: 2,
+          checkpoint_sequence: 2,
+        }),
+      ],
+    });
+
+    const root = await renderGraphs([personal]);
+
+    expect(
+      latest?.graphs?.map((graph) => [
+        graph.name,
+        graph.draft_pending,
+        graph.revision,
+      ]),
+    ).toEqual([
+      ["graph-pending", true, 1],
+      ["graph-checkpointed", false, 1],
+    ]);
+
+    await act(async () => root.unmount());
+  });
+});
+
+describe("graph summary cache invalidation", () => {
+  it("refreshes every discovery surface affected by a workspace mutation", async () => {
+    const mutate = vi.fn().mockResolvedValue(undefined);
+
+    await revalidateGraphSummaries(mutate, personal.id);
+
+    expect(mutate.mock.calls).toEqual([
+      [workspaceGraphsKey(personal.id)],
+      [ALL_GRAPHS_KEY],
+    ]);
+    expect(workspaceGraphsKey(personal.id)).toBe(
+      "/v1/workspaces/workspace-personal/graphs",
+    );
+  });
+
+  it("refreshes the cross-workspace list when no workspace is scoped", async () => {
+    const mutate = vi.fn().mockResolvedValue(undefined);
+
+    await revalidateGraphSummaries(mutate);
+
+    expect(mutate.mock.calls).toEqual([[ALL_GRAPHS_KEY]]);
   });
 });

--- a/apps/web/src/hooks/use-api.ts
+++ b/apps/web/src/hooks/use-api.ts
@@ -1,12 +1,14 @@
 "use client";
 
-import useSWR from "swr";
+import * as React from "react";
+import useSWR, { useSWRConfig, type ScopedMutator } from "swr";
 import {
   type GraphBrowserList,
   listWorkspaceMembers,
   listWorkspaces,
   type NodeRegistry,
   type SavedGraphList,
+  type SavedGraphSummary,
   type Workspace,
   type WorkspaceInvitation,
   type WorkspaceInvitationForRecipient,
@@ -16,7 +18,45 @@ import {
 } from "@/lib/api";
 import { request } from "@/lib/api/client";
 
-/** Keyed SWR hooks over the Grafy API (global fetcher is `apiFetcher`). */
+/**
+ * Keyed SWR hooks over the Grafy API (global fetcher is `apiFetcher`).
+ *
+ * Graph summaries come from two endpoints that share one authoritative
+ * contract: node and edge counts plus `updated_at` always describe the
+ * collaborative draft head, `revision` is the durable checkpoint revision,
+ * and `draft_pending` marks a head that is ahead of that checkpoint.
+ */
+
+/** Every graph the user can reach, across workspaces. */
+export const ALL_GRAPHS_KEY = "/v1/me/graphs";
+
+/** Saved graphs inside one workspace. */
+export function workspaceGraphsKey(workspaceId: string): string {
+  return `/v1/workspaces/${encodeURIComponent(workspaceId)}/graphs`;
+}
+
+/** Revalidate every discovery surface affected by a graph mutation. */
+export async function revalidateGraphSummaries(
+  mutate: ScopedMutator,
+  workspaceId?: string,
+): Promise<void> {
+  const keys = [
+    workspaceId ? workspaceGraphsKey(workspaceId) : null,
+    ALL_GRAPHS_KEY,
+  ];
+  await Promise.all(keys.filter((key) => key !== null).map((key) => mutate(key)));
+}
+
+/** Revalidate both graph-list caches from any component. */
+export function useGraphSummaryRefresh(): (
+  workspaceId?: string,
+) => Promise<void> {
+  const { mutate } = useSWRConfig();
+  return React.useCallback(
+    (workspaceId?: string) => revalidateGraphSummaries(mutate, workspaceId),
+    [mutate],
+  );
+}
 
 export function useNodeRegistry(workspaceId?: string) {
   return useSWR<NodeRegistry>(
@@ -28,9 +68,7 @@ export function useNodeRegistry(workspaceId?: string) {
 
 export function useSavedGraphs(workspaceId?: string) {
   return useSWR<SavedGraphList>(
-    workspaceId
-      ? `/v1/workspaces/${encodeURIComponent(workspaceId)}/graphs`
-      : null,
+    workspaceId ? workspaceGraphsKey(workspaceId) : null,
   );
 }
 
@@ -46,13 +84,7 @@ export type GraphLocation = Pick<
   "id" | "slug" | "name" | "kind"
 >;
 
-export interface LocatedGraph {
-  id: string;
-  name: string;
-  revision: number;
-  node_count: number;
-  edge_count: number;
-  updated_at: string;
+export interface LocatedGraph extends SavedGraphSummary {
   location: GraphLocation;
   folder: { id: string; name: string } | null;
   archived: boolean;
@@ -64,6 +96,8 @@ export interface AllWorkspacesGraphsResult {
   graphs: readonly LocatedGraph[] | null;
   error: Error | null;
   isLoading: boolean;
+  /** True while a revalidation is in flight over cached summaries. */
+  isRefreshing: boolean;
   retry: () => Promise<void>;
 }
 
@@ -71,7 +105,7 @@ export function useAllWorkspacesGraphs(
   workspaces: readonly Workspace[] | undefined,
 ): AllWorkspacesGraphsResult {
   const load = useSWR<GraphBrowserList>(
-    workspaces && workspaces.length > 0 ? "/v1/me/graphs" : null,
+    workspaces && workspaces.length > 0 ? ALL_GRAPHS_KEY : null,
     (path: string) => request<GraphBrowserList>("GET", path),
     { shouldRetryOnError: false },
   );
@@ -85,6 +119,8 @@ export function useAllWorkspacesGraphs(
           node_count: graph.draft.node_count,
           edge_count: graph.draft.edge_count,
           updated_at: graph.updated_at,
+          draft_pending:
+            graph.draft.head_sequence > graph.draft.checkpoint_sequence,
           location: graph.location,
           folder: graph.folder,
           archived: graph.archived,
@@ -96,6 +132,7 @@ export function useAllWorkspacesGraphs(
     graphs,
     error: load.error instanceof Error ? load.error : null,
     isLoading: Boolean(workspaces?.length) && load.isLoading,
+    isRefreshing: load.isValidating && !load.isLoading,
     retry: async () => {
       if (workspaces?.length) await load.mutate();
     },

--- a/apps/web/src/lib/api/generated/grafy.ts
+++ b/apps/web/src/lib/api/generated/grafy.ts
@@ -3184,8 +3184,18 @@ export interface components {
              */
             readonly updated_at: string;
         };
-        /** SavedGraphSummaryResponse */
+        /**
+         * SavedGraphSummaryResponse
+         * @description Authoritative summary shared by every graph discovery surface.
+         *
+         *     Counts and ``updated_at`` describe the collaborative draft head (what the
+         *     canvas shows). ``revision`` is the durable checkpoint revision used by
+         *     lifecycle writes, and ``draft_pending`` labels a head that is ahead of that
+         *     checkpoint.
+         */
         readonly SavedGraphSummaryResponse: {
+            /** Draft Pending */
+            readonly draft_pending: boolean;
             /** Edge Count */
             readonly edge_count: number;
             /**

--- a/libs/core/src/grafy_core/application/saved_graphs.py
+++ b/libs/core/src/grafy_core/application/saved_graphs.py
@@ -82,9 +82,17 @@ class SavedGraphService:
                 raise NotFoundError("Saved graph", str(graph_id))
             return await unit_of_work.graphs.list_revisions(workspace_id, graph_id)
 
-    async def list_accessible(self, actor: ActorContext) -> list[GraphBrowserItem]:
+    async def list_accessible(
+        self,
+        actor: ActorContext,
+        *,
+        workspace_id: UUID | None = None,
+    ) -> list[GraphBrowserItem]:
         async with self._unit_of_work_factory() as unit_of_work:
-            return await unit_of_work.graphs.list_accessible(actor.user_id)
+            return await unit_of_work.graphs.list_accessible(
+                actor.user_id,
+                workspace_id=workspace_id,
+            )
 
     async def create_folder(
         self,

--- a/libs/core/src/grafy_core/ports/saved_graphs.py
+++ b/libs/core/src/grafy_core/ports/saved_graphs.py
@@ -49,7 +49,12 @@ class SavedGraphRepositoryPort(Protocol):
         graph_id: UUID,
     ) -> list[SavedGraphRevision]: ...
 
-    async def list_accessible(self, user_id: UUID) -> list[GraphBrowserItem]: ...
+    async def list_accessible(
+        self,
+        user_id: UUID,
+        *,
+        workspace_id: UUID | None = None,
+    ) -> list[GraphBrowserItem]: ...
 
     async def add_folder(self, folder: GraphFolder) -> None: ...
 

--- a/libs/persistence/src/grafy_persistence/adapters/repositories/graphs.py
+++ b/libs/persistence/src/grafy_persistence/adapters/repositories/graphs.py
@@ -143,7 +143,12 @@ class SqlSavedGraphRepository(SavedGraphRepositoryPort):
         ]
 
     @override
-    async def list_accessible(self, user_id: UUID) -> list[GraphBrowserItem]:
+    async def list_accessible(
+        self,
+        user_id: UUID,
+        *,
+        workspace_id: UUID | None = None,
+    ) -> list[GraphBrowserItem]:
         graphs = schema.saved_graphs
         memberships = schema.workspace_memberships
         workspaces = schema.workspaces
@@ -153,30 +158,29 @@ class SqlSavedGraphRepository(SavedGraphRepositoryPort):
         heads = schema.collaborative_graph_heads
         active_user = schema.users.alias("active_graph_browser_user")
         creator = schema.users.alias("graph_creator")
-        rows = (
-            await self._session.execute(
-                select(
-                    graphs.c.id,
-                    organizations.c.archived_at,
-                    organizations.c.updated_at.label("organization_updated_at"),
-                    heads.c.name.label("head_name"),
-                    heads.c.document.label("head_document"),
-                    heads.c.collaboration_sequence,
-                    heads.c.checkpoint_sequence,
-                    heads.c.checkpoint_revision,
-                    heads.c.updated_at.label("head_updated_at"),
-                    workspaces.c.id.label("workspace_id"),
-                    workspaces.c.slug.label("workspace_slug"),
-                    workspaces.c.name.label("workspace_name"),
-                    workspaces.c.kind.label("workspace_kind"),
-                    folders.c.id.label("folder_id"),
-                    folders.c.name.label("folder_name"),
-                    states.c.starred,
-                    states.c.last_opened_at,
-                    creator.c.id.label("creator_id"),
-                    creator.c.display_name.label("creator_display_name"),
-                )
-                .select_from(
+        query = (
+            select(
+                graphs.c.id,
+                organizations.c.archived_at,
+                organizations.c.updated_at.label("organization_updated_at"),
+                heads.c.name.label("head_name"),
+                heads.c.document.label("head_document"),
+                heads.c.collaboration_sequence,
+                heads.c.checkpoint_sequence,
+                heads.c.checkpoint_revision,
+                heads.c.updated_at.label("head_updated_at"),
+                workspaces.c.id.label("workspace_id"),
+                workspaces.c.slug.label("workspace_slug"),
+                workspaces.c.name.label("workspace_name"),
+                workspaces.c.kind.label("workspace_kind"),
+                folders.c.id.label("folder_id"),
+                folders.c.name.label("folder_name"),
+                states.c.starred,
+                states.c.last_opened_at,
+                creator.c.id.label("creator_id"),
+                creator.c.display_name.label("creator_display_name"),
+            )
+            .select_from(
                     graphs.join(
                         memberships,
                         and_(
@@ -229,14 +233,16 @@ class SqlSavedGraphRepository(SavedGraphRepositoryPort):
                             states.c.user_id == user_id,
                         ),
                     )
-                    .outerjoin(creator, creator.c.id == graphs.c.created_by_user_id)
-                )
-                .order_by(
-                    heads.c.updated_at.desc(),
-                    graphs.c.id.asc(),
-                )
+                .outerjoin(creator, creator.c.id == graphs.c.created_by_user_id)
             )
-        ).mappings()
+            .order_by(
+                heads.c.updated_at.desc(),
+                graphs.c.id.asc(),
+            )
+        )
+        if workspace_id is not None:
+            query = query.where(graphs.c.workspace_id == workspace_id)
+        rows = (await self._session.execute(query)).mappings()
         items: list[GraphBrowserItem] = []
         for row in rows:
             document = cast(SavedGraphDocument, row["head_document"])

--- a/tests/integration/saved_graphs/test_saved_graphs.py
+++ b/tests/integration/saved_graphs/test_saved_graphs.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import cast
 from uuid import UUID, uuid4
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from grafy_api.v1.models import ArtifactTypeBindingModel, ArtifactTypeKeyResponse
@@ -19,7 +20,7 @@ from grafy_api.graph_contracts import (
     SubmitGraphCommandRequest,
     UpdateSavedGraphRequest,
 )
-from grafy_core.domain.collaboration import RenameGraphCommand
+from grafy_core.domain.collaboration import RemoveNodesCommand, RenameGraphCommand
 from grafy_core.domain.identity import ActorContext
 from grafy_core.domain.saved_graphs import SavedGraphDocument
 
@@ -87,7 +88,7 @@ def _graph_document(
 ) -> SavedGraphDocument:
     effective_nodes = nodes if nodes is not None else _graph_nodes()
     effective_edges = edges if edges is not None else _graph_edges()
-    serialized_nodes = []
+    serialized_nodes: list[dict[str, object]] = []
     for node in effective_nodes:
         serialized = node.model_dump(mode="json")
         serialized["plugin_release_pin"] = serialized.pop("plugin_release")
@@ -272,20 +273,18 @@ def test_saved_graph_crud_round_trip(builtin_client: TestClient) -> None:
     assert get_response.status_code == 200
     assert get_response.json() == created
 
+    head = graphs.get_head_ok(graph_id)
     list_response = graphs.list()
     assert list_response.status_code == 200
-    assert list_response.json() == {
-        "graphs": [
-            {
-                "id": str(graph_id),
-                "name": "Parish index draft",
-                "revision": 1,
-                "node_count": 2,
-                "edge_count": 1,
-                "updated_at": created["updated_at"],
-            }
-        ]
-    }
+    listed = graphs.list_ok()
+    assert len(listed.graphs) == 1
+    summary = listed.graphs[0]
+    assert summary.id == graph_id
+    assert summary.name == "Parish index draft"
+    assert summary.revision == 1
+    assert (summary.node_count, summary.edge_count) == (2, 1)
+    assert summary.updated_at == head.updated_at
+    assert summary.draft_pending is False
 
     update_response = graphs.update(
         graph_id, _update_request("Updated draft", expected_revision=1)
@@ -301,6 +300,70 @@ def test_saved_graph_crud_round_trip(builtin_client: TestClient) -> None:
     assert delete_response.status_code == 204
     assert delete_response.content == b""
     assert graphs.get(graph_id).status_code == 404
+
+
+def test_graph_lists_agree_on_the_live_draft_head_summary(
+    builtin_client: TestClient,
+) -> None:
+    """Every discovery surface reads the draft head, and labels a pending draft."""
+
+    api = GrafyApi(builtin_client)
+    graphs = api.workspace(WORKSPACE_ID).graphs
+    created = graphs.create(_graph_request("Shared summary")).json()
+    graph_id = UUID(created["id"])
+    head = graphs.get_head_ok(graph_id)
+
+    # Remove both nodes from the live head without checkpointing, so the draft
+    # head and the saved checkpoint deliberately disagree.
+    command = graphs.submit_command_ok(
+        graph_id,
+        SubmitGraphCommandRequest(
+            command_id=uuid4(),
+            room_epoch=head.room_epoch,
+            observed_sequence=head.collaboration_sequence,
+            command=RemoveNodesCommand(node_ids=("source", "target")),
+        ),
+    )
+
+    listed = graphs.list_ok()
+    assert len(listed.graphs) == 1
+    summary = listed.graphs[0]
+    browser = api.graph_browser.list_ok().graphs[0]
+
+    # The workspace list describes the live draft head, not the stale checkpoint.
+    assert (summary.node_count, summary.edge_count) == (0, 0)
+    assert summary.updated_at == command.head.updated_at
+    assert summary.draft_pending is True
+    # The durable revision still points at the last checkpoint for lifecycle writes.
+    assert summary.revision == 1
+    assert summary.name == "Shared summary"
+
+    # Both surfaces describe the same graph the same way.
+    assert browser.id == summary.id
+    assert browser.draft.name == summary.name
+    assert (browser.draft.node_count, browser.draft.edge_count) == (
+        summary.node_count,
+        summary.edge_count,
+    )
+    assert browser.updated_at == summary.updated_at
+    assert browser.draft.updated_at == summary.updated_at
+    assert browser.draft.checkpoint_revision == summary.revision
+
+    # Checkpointing clears the pending label on both surfaces.
+    checkpoint = graphs.checkpoint_ok(
+        graph_id,
+        CheckpointGraphRequest(
+            expected_room_epoch=command.head.room_epoch,
+            expected_sequence=command.head.collaboration_sequence,
+        ),
+    )
+    after = graphs.list_ok().graphs[0]
+    assert after.draft_pending is False
+    assert after.revision == checkpoint.saved_revision
+    assert after.updated_at == checkpoint.head.updated_at
+    assert api.graph_browser.list_ok().graphs[0].draft.checkpoint_revision == (
+        checkpoint.saved_revision
+    )
 
 
 def test_create_rejects_structurally_invalid_graph(builtin_client: TestClient) -> None:
@@ -333,7 +396,7 @@ def test_create_rejects_ambiguous_conversion_fields(
     payload = _canonical_raw_graph_payload()
     document = cast(dict[str, object], payload["document"])
     edge = cast(list[dict[str, object]], document["edges"])[0]
-    edge["conversion"] = edge["conversion_path"][0]
+    edge["conversion"] = cast(list[object], edge["conversion_path"])[0]
 
     response = builtin_client.post(
         "/v1/workspaces/00000000-0000-0000-0000-000000000007/graphs", json=payload
@@ -560,7 +623,7 @@ def test_http_replace_rejects_uncheckpointed_head(
     graphs = api.workspace(WORKSPACE_ID).graphs
     created = graphs.create(_graph_request("Live draft")).json()
     graph_id = UUID(created["id"])
-    collaboration = builtin_client.app.state.resources.collaboration
+    collaboration = cast(FastAPI, builtin_client.app).state.resources.collaboration
     head = graphs.get_head_ok(graph_id)
     asyncio.run(
         collaboration.accept_command(

--- a/tests/unit/core/test_saved_graphs.py
+++ b/tests/unit/core/test_saved_graphs.py
@@ -16,7 +16,6 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphAnnotationLayout,
     SavedGraphArtifactTypeBinding,
     SavedGraphDocument,
-    SavedGraphConversion,
     SavedGraphEdge,
     SavedGraphInputPlug,
     SavedGraphNode,


### PR DESCRIPTION
Closes #12.

Quick switch and workspace Graphs now use the same collaborative draft summary as All graphs and Recent. An uncheckpointed edit therefore shows the same node count and freshness in both lists.

Counts and freshness describe the draft head. `revision` remains the durable checkpoint revision for lifecycle writes, and `draft_pending` identifies unsaved draft changes. Save, rename, delete, and room rehydration refresh both list caches. Rows share count wording and show draft and refresh states.

## Validation

Updated against current main, including origins/schema 7 and artifact cards, with merge commits that preserve branch history.

- 148 focused backend and HTTP tests passed, including list agreement before and after checkpointing.
- 643 web tests passed.
- TypeScript checking, Python lint, web lint, and generated API-contract checks passed.
