### PR TITLE
feat(library): record and show how a Library artifact came to be

### DIFF
--- a/apps/api/src/grafy_api/main.py
+++ b/apps/api/src/grafy_api/main.py
@@ -6,49 +6,53 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
-
-from grafy_api.health import HealthResponse, health, readiness
 from grafy_core.application.collaboration import CollaborationService
+from grafy_core.application.identity import IdentityService
 from grafy_core.application.modules import ModuleLibraryService
 from grafy_core.application.plugin_releases import PluginReleaseService
 from grafy_core.application.saved_graphs import SavedGraphService
 from grafy_core.application.templates import TemplateService
-from grafy_core.application.identity import IdentityService
-from grafy_workbench import BuiltinNodeCatalog
-
 from grafy_persistence.database import create_database
 from grafy_persistence.unit_of_work import (
     SqlAlchemySavedGraphUnitOfWork,
     SqlAlchemyUnitOfWork,
 )
+from grafy_workbench import BuiltinNodeCatalog
+
 from grafy_api.app_state import AppIdentity, AppResources, get_identity
 from grafy_api.diagnostics import configure_diagnostics
+from grafy_api.health import HealthResponse, health, readiness
 from grafy_api.http_errors import register_http_error_handlers
+from grafy_api.node_secrets import NodeSecretService
 from grafy_api.plugins.profiles import runtime_profile
+from grafy_api.plugins.runtime.docker import DockerPluginRuntime
+from grafy_api.realtime.hub import GraphRoomHub
 from grafy_api.services.composition import build_workbench_components
 from grafy_api.settings import Settings, get_settings
 from grafy_api.single_owner import ApiOwnerLease
 from grafy_api.storage import configured_file_storage
+from grafy_api.v1.routes.artifacts.views import router as artifacts_router
 from grafy_api.v1.routes.auth.services import AuthService
 from grafy_api.v1.routes.auth.views import router as auth_router
-from grafy_api.v1.routes.artifacts.views import router as artifacts_router
 from grafy_api.v1.routes.catalog.views import router as catalog_router
-from grafy_api.v1.routes.modules.views import router as modules_router
-from grafy_api.v1.routes.templates.views import router as templates_router
-from grafy_api.realtime.hub import GraphRoomHub
 from grafy_api.v1.routes.collaboration.views import router as collaboration_router
 from grafy_api.v1.routes.executions.views import router as executions_router
-from grafy_api.plugins.runtime.docker import DockerPluginRuntime
-from grafy_api.node_secrets import NodeSecretService
+from grafy_api.v1.routes.library.views import router as library_router
+from grafy_api.v1.routes.modules.views import router as modules_router
 from grafy_api.v1.routes.node_secrets.views import router as node_secrets_router
 from grafy_api.v1.routes.saved_graphs.views import (
     browser_router as graph_browser_router,
+)
+from grafy_api.v1.routes.saved_graphs.views import (
     folder_router as graph_folders_router,
+)
+from grafy_api.v1.routes.saved_graphs.views import (
     router as saved_graphs_router,
 )
+from grafy_api.v1.routes.templates.views import router as templates_router
 from grafy_api.v1.routes.uploads.views import router as uploads_router
-from grafy_api.v1.routes.workspaces.views import me_router, router as workspaces_router
-
+from grafy_api.v1.routes.workspaces.views import me_router
+from grafy_api.v1.routes.workspaces.views import router as workspaces_router
 
 logger = logging.getLogger(__name__)
 
@@ -359,6 +363,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     application.include_router(uploads_router, prefix="/v1")
     application.include_router(executions_router, prefix="/v1")
     application.include_router(artifacts_router, prefix="/v1")
+    application.include_router(library_router, prefix="/v1")
     return application
 
 

--- a/apps/api/src/grafy_api/services/composition.py
+++ b/apps/api/src/grafy_api/services/composition.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from grafy_core.runtime.in_memory import InMemoryUnitOfWork
 from grafy_core.application.modules import ModuleLibraryService
 from grafy_core.application.plugin_releases import PluginReleaseService
 from grafy_core.application.saved_graphs import SavedGraphService
@@ -21,38 +20,39 @@ from grafy_core.ports.node_secrets import (
 )
 from grafy_core.ports.storage import FileStoragePort
 from grafy_core.runtime.execution import NodeRuntime
+from grafy_core.runtime.in_memory import InMemoryUnitOfWork
 from grafy_core.runtime.materialization import InputMaterializer
 from grafy_core.runtime.persistence import (
     ArtifactWriterRegistry,
     OutputPersister,
 )
+from grafy_core.runtime.persistent_invocation_cache import PersistentInvocationCache
 from grafy_core.runtime.resolvers import ResolverRegistry
 from grafy_storage import LocalFileObjectStore
 
-from grafy_api.plugins.runtime.admission import (
-    ReleaseExecutionAdmission,
-)
-from grafy_api.plugins.runtime.network_policy import NetworkPolicy
-from grafy_api.v1.routes.artifacts.services import ArtifactService
-from grafy_api.realtime.hub import GraphRoomHub
+from grafy_api.artifact_availability import ArtifactAvailability
+from grafy_api.execution.admission import ExecutionAdmissionLimiter
 from grafy_api.execution.compiler import GraphCompiler
 from grafy_api.execution.coordinator import GraphExecutionCoordinator
 from grafy_api.execution.edge_values import EdgeValueResolver
-from grafy_core.runtime.persistent_invocation_cache import PersistentInvocationCache
+from grafy_api.execution.history import ExecutionHistoryService
 from grafy_api.execution.manager import RunExecutionManager
+from grafy_api.execution.materializations import MaterializationService
 from grafy_api.execution.node_execution import NodeExecutionService
-from grafy_api.plugins.runtime.artifacts import ArtifactBundlePluginInvoker
-from grafy_api.plugins.runtime.docker import DockerPluginRuntime
-from grafy_api.execution.admission import ExecutionAdmissionLimiter
 from grafy_api.execution.preflight import GraphRunPreflight
 from grafy_api.execution.run_graph import RunGraph
-from grafy_api.execution.history import ExecutionHistoryService
-from grafy_api.execution.materializations import MaterializationService
-from grafy_api.artifact_availability import ArtifactAvailability
-from grafy_api.v1.routes.executions.services import RunResultPresenter
+from grafy_api.plugins.runtime.admission import (
+    ReleaseExecutionAdmission,
+)
+from grafy_api.plugins.runtime.artifacts import ArtifactBundlePluginInvoker
+from grafy_api.plugins.runtime.docker import DockerPluginRuntime
+from grafy_api.plugins.runtime.network_policy import NetworkPolicy
+from grafy_api.realtime.hub import GraphRoomHub
 from grafy_api.settings import STAGED_UPLOAD_HARD_MAX_BYTES
 from grafy_api.staged_uploads import StagedUploadService
-
+from grafy_api.v1.routes.artifacts.services import ArtifactService
+from grafy_api.v1.routes.executions.services import RunResultPresenter
+from grafy_api.v1.routes.library.services import LibraryService
 
 _WORKBENCH_BUCKET = "workbench-artifacts"
 
@@ -70,6 +70,7 @@ class WorkbenchComponents:
     materializations: MaterializationService
     presenter: RunResultPresenter
     artifacts: ArtifactService
+    library: LibraryService
     plugin_invoker: ArtifactBundlePluginInvoker | None
     plugin_runtime: DockerPluginRuntime | None
     release_admission: ReleaseExecutionAdmission | None
@@ -141,14 +142,15 @@ def build_workbench_components(
     )
 
     availability = ArtifactAvailability(resolved_unit_of_work, resolved_storage)
+    artifact_types = {
+        (spec.key.id, spec.key.schema_version): spec
+        for spec in plugin_registry.artifact_types
+    }
     artifacts = ArtifactService(
         resolved_unit_of_work,
         resolved_storage,
         availability=availability,
-        artifact_types={
-            (spec.key.id, spec.key.schema_version): spec
-            for spec in plugin_registry.artifact_types
-        },
+        artifact_types=artifact_types,
     )
     materializations = MaterializationService(
         resolved_unit_of_work,
@@ -156,6 +158,12 @@ def build_workbench_components(
         saved_graphs,
     )
     presenter = RunResultPresenter(artifacts, availability)
+    library = LibraryService(
+        resolved_unit_of_work,
+        artifacts,
+        artifact_types=artifact_types,
+        saved_graphs=saved_graphs,
+    )
     plugin_invoker = None
     artifact_plugin_invoker = None
     release_admission: ReleaseExecutionAdmission | None = None
@@ -252,6 +260,7 @@ def build_workbench_components(
         materializations=materializations,
         presenter=presenter,
         artifacts=artifacts,
+        library=library,
         plugin_invoker=artifact_plugin_invoker,
         plugin_runtime=plugin_runtime,
         release_admission=release_admission,

--- a/apps/api/src/grafy_api/v1/routes/library/__init__.py
+++ b/apps/api/src/grafy_api/v1/routes/library/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace Library artifact endpoints."""

--- a/apps/api/src/grafy_api/v1/routes/library/dependencies.py
+++ b/apps/api/src/grafy_api/v1/routes/library/dependencies.py
@@ -1,0 +1,17 @@
+from typing import Annotated
+
+from fastapi import Depends, Request
+
+from grafy_api.app_state import get_resources
+
+from .services import LibraryService
+
+
+def library_service(request: Request) -> LibraryService:
+    return get_resources(request.app).workbench.library
+
+
+LibraryDependency = Annotated[LibraryService, Depends(library_service)]
+
+
+__all__ = ["LibraryDependency", "library_service"]

--- a/apps/api/src/grafy_api/v1/routes/library/models.py
+++ b/apps/api/src/grafy_api/v1/routes/library/models.py
@@ -1,0 +1,94 @@
+from datetime import datetime
+from typing import Annotated, Literal
+from uuid import UUID
+
+from grafy_core.artifacts import LibraryProvenance
+from pydantic import StringConstraints
+
+from grafy_api.v1.models import ApiResponse
+from grafy_api.v1.routes.artifacts.models import ArtifactSummaryResponse
+
+BoundedNodeId = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+]
+BoundedFilename = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+]
+
+
+class LibraryProvenanceResponse(ApiResponse):
+    """The birth record frozen when the artifact entered the Library."""
+
+    source: Literal["run", "upload"]
+    saved_at: datetime
+    graph_id: UUID | None = None
+    graph_title: str | None = None
+    node_id: str | None = None
+    node_title: str | None = None
+    graph_revision: int | None = None
+    execution_id: UUID | None = None
+    original_filename: str | None = None
+
+    @classmethod
+    def from_provenance(cls, provenance: LibraryProvenance) -> "LibraryProvenanceResponse":
+        return cls(
+            source=provenance.source,
+            saved_at=provenance.saved_at,
+            graph_id=provenance.graph_id,
+            graph_title=provenance.graph_title,
+            node_id=provenance.node_id,
+            node_title=provenance.node_title,
+            graph_revision=provenance.graph_revision,
+            execution_id=provenance.execution_id,
+            original_filename=provenance.original_filename,
+        )
+
+
+class LibraryRunResponse(ApiResponse):
+    """The retained run behind a run-sourced Library item.
+
+    Present only while execution history still holds the run, which is exactly
+    when the item can link back to it.
+    """
+
+    execution_id: UUID
+    graph_id: UUID
+    finished_at: datetime | None = None
+
+
+class LibraryItemResponse(ApiResponse):
+    artifact: ArtifactSummaryResponse
+    name: str
+    provenance: LibraryProvenanceResponse
+    run: LibraryRunResponse | None = None
+
+
+class LibraryListResponse(ApiResponse):
+    items: list[LibraryItemResponse]
+
+
+class SaveRunArtifactRequest(ApiResponse):
+    artifact_id: UUID
+    execution_id: UUID
+    node_id: BoundedNodeId
+    node_title: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=160),
+    ]
+
+
+class SaveUploadedArtifactRequest(ApiResponse):
+    artifact_id: UUID
+    original_filename: BoundedFilename
+
+
+__all__ = [
+    "LibraryItemResponse",
+    "LibraryListResponse",
+    "LibraryProvenanceResponse",
+    "LibraryRunResponse",
+    "SaveRunArtifactRequest",
+    "SaveUploadedArtifactRequest",
+]

--- a/apps/api/src/grafy_api/v1/routes/library/services.py
+++ b/apps/api/src/grafy_api/v1/routes/library/services.py
@@ -1,0 +1,271 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from grafy_core.application.saved_graphs import SavedGraphService
+from grafy_core.artifacts import (
+    ArtifactObject,
+    ArtifactRefSequence,
+    ArtifactTypeSpec,
+    LibraryProvenance,
+)
+from grafy_core.domain.artifact_outputs import ArtifactOutputValue
+from grafy_core.domain.errors import NotFoundError
+from grafy_core.domain.execution_history import GraphExecutionDetail
+from grafy_core.ports.materialized_outputs import WorkbenchUnitOfWorkPort
+
+from grafy_api.services.errors import WorkbenchOperationError
+from grafy_api.v1.routes.artifacts.models import (
+    ArtifactExportFormatResponse,
+    ArtifactSummaryResponse,
+)
+from grafy_api.v1.routes.artifacts.services import ArtifactService
+
+from .models import (
+    LibraryItemResponse,
+    LibraryProvenanceResponse,
+    LibraryRunResponse,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryRun:
+    execution_id: UUID
+    graph_id: UUID
+    finished_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryItem:
+    artifact: ArtifactObject
+    provenance: LibraryProvenance
+    run: LibraryRun | None
+
+
+def _output_artifact_ids(outputs: Mapping[str, ArtifactOutputValue]) -> set[UUID]:
+    artifact_ids: set[UUID] = set()
+    for output in outputs.values():
+        if isinstance(output, ArtifactRefSequence):
+            artifact_ids.update(ref.artifact_id for ref in output.item_refs)
+        else:
+            artifact_ids.add(output.artifact_id)
+    return artifact_ids
+
+
+class LibraryService:
+    """Save artifacts into a Workspace Library and read the Library back.
+
+    A Library artifact is an ordinary artifact row carrying a provenance
+    snapshot. Saving records how the artifact came to be and nothing else: it
+    moves no bytes and creates no second record.
+    """
+
+    def __init__(
+        self,
+        unit_of_work: WorkbenchUnitOfWorkPort,
+        artifacts: ArtifactService,
+        artifact_types: Mapping[tuple[str, int], ArtifactTypeSpec],
+        saved_graphs: SavedGraphService | None = None,
+    ) -> None:
+        self._unit_of_work = unit_of_work
+        self._artifacts = artifacts
+        self._artifact_types = artifact_types
+        self._saved_graphs = saved_graphs
+
+    async def list_items(self, workspace_id: UUID) -> list[LibraryItemResponse]:
+        items: list[LibraryItem] = []
+        async with self._unit_of_work as unit_of_work:
+            artifacts = await unit_of_work.artifacts.list_library(workspace_id)
+            for artifact in artifacts:
+                provenance = artifact.library_provenance
+                if provenance is None:
+                    continue
+                items.append(
+                    LibraryItem(
+                        artifact=artifact,
+                        provenance=provenance,
+                        run=await self._retained_run(unit_of_work, artifact, provenance),
+                    )
+                )
+        items.sort(
+            key=lambda item: (item.provenance.saved_at, str(item.artifact.id)),
+            reverse=True,
+        )
+        return [self._present(item) for item in items]
+
+    async def _retained_run(
+        self,
+        unit_of_work: WorkbenchUnitOfWorkPort,
+        artifact: ArtifactObject,
+        provenance: LibraryProvenance,
+    ) -> LibraryRun | None:
+        if provenance.source != "run" or provenance.execution_id is None:
+            return None
+        detail = await unit_of_work.execution_history.get(
+            artifact.workspace_id,
+            provenance.execution_id,
+        )
+        if detail is None:
+            return None
+        return LibraryRun(
+            execution_id=detail.execution.execution_id,
+            graph_id=detail.execution.graph_id,
+            finished_at=detail.execution.finished_at,
+        )
+
+    async def save_from_run(
+        self,
+        *,
+        workspace_id: UUID,
+        artifact_id: UUID,
+        execution_id: UUID,
+        node_id: str,
+        node_title: str,
+    ) -> LibraryItemResponse:
+        detail = await self._load_execution(workspace_id, execution_id)
+        node_result = next(
+            (result for result in detail.node_results if result.node_id == node_id),
+            None,
+        )
+        if node_result is None:
+            raise WorkbenchOperationError(
+                f"Execution {execution_id} has no node result {node_id!r}"
+            )
+        if artifact_id not in _output_artifact_ids(node_result.outputs):
+            raise WorkbenchOperationError(
+                f"Artifact {artifact_id} is not an output of node {node_id!r} "
+                f"in execution {execution_id}"
+            )
+        graph_title = await self._graph_title(workspace_id, detail.execution.graph_id)
+        provenance = LibraryProvenance.from_run(
+            saved_at=datetime.now(UTC),
+            graph_id=detail.execution.graph_id,
+            graph_title=graph_title,
+            node_id=node_id,
+            node_title=node_title,
+            graph_revision=detail.execution.graph_revision,
+            execution_id=execution_id,
+        )
+        return await self._record(
+            workspace_id,
+            artifact_id,
+            provenance,
+            LibraryRun(
+                execution_id=execution_id,
+                graph_id=detail.execution.graph_id,
+                finished_at=detail.execution.finished_at,
+            ),
+        )
+
+    async def save_uploaded(
+        self,
+        *,
+        workspace_id: UUID,
+        artifact_id: UUID,
+        original_filename: str,
+    ) -> LibraryItemResponse:
+        provenance = LibraryProvenance.from_upload(
+            saved_at=datetime.now(UTC),
+            original_filename=original_filename,
+        )
+        return await self._record(workspace_id, artifact_id, provenance, None)
+
+    async def _record(
+        self,
+        workspace_id: UUID,
+        artifact_id: UUID,
+        provenance: LibraryProvenance,
+        run: LibraryRun | None,
+    ) -> LibraryItemResponse:
+        async with self._unit_of_work as unit_of_work:
+            artifact = await unit_of_work.artifacts.get(workspace_id, artifact_id)
+            if artifact is None:
+                raise NotFoundError("Artifact", str(artifact_id))
+            if artifact.library_provenance is not None:
+                # Provenance is a birth record; re-saving never rewrites it.
+                return self._present(
+                    LibraryItem(
+                        artifact=artifact,
+                        provenance=artifact.library_provenance,
+                        run=await self._retained_run(
+                            unit_of_work,
+                            artifact,
+                            artifact.library_provenance,
+                        ),
+                    )
+                )
+            artifact.library_provenance = provenance
+            await unit_of_work.commit()
+        return self._present(
+            LibraryItem(artifact=artifact, provenance=provenance, run=run)
+        )
+
+    async def _load_execution(
+        self,
+        workspace_id: UUID,
+        execution_id: UUID,
+    ) -> GraphExecutionDetail:
+        async with self._unit_of_work as unit_of_work:
+            detail = await unit_of_work.execution_history.get(
+                workspace_id,
+                execution_id,
+            )
+        if detail is None:
+            raise NotFoundError("Graph execution", str(execution_id))
+        return detail
+
+    async def _graph_title(self, workspace_id: UUID, graph_id: UUID) -> str:
+        if self._saved_graphs is None:
+            raise RuntimeError(
+                "Saved graph context is not configured for Library provenance"
+            )
+        graph = await self._saved_graphs.get(workspace_id, graph_id)
+        return graph.name
+
+    def _present(self, item: LibraryItem) -> LibraryItemResponse:
+        return LibraryItemResponse(
+            artifact=self._artifact_summary(item.artifact),
+            name=self._artifact_name(item.artifact),
+            provenance=LibraryProvenanceResponse.from_provenance(item.provenance),
+            run=(
+                None
+                if item.run is None
+                else LibraryRunResponse(
+                    execution_id=item.run.execution_id,
+                    graph_id=item.run.graph_id,
+                    finished_at=item.run.finished_at,
+                )
+            ),
+        )
+
+    def _artifact_summary(self, artifact: ArtifactObject) -> ArtifactSummaryResponse:
+        return ArtifactSummaryResponse(
+            artifact_id=artifact.id,
+            artifact_type=artifact.artifact_type,
+            schema_version=artifact.schema_version,
+            content_type=artifact.content_type,
+            byte_size=artifact.byte_size,
+            sha256=artifact.sha256,
+            content_url=f"./artifacts/{artifact.id}/content",
+            download_formats=[
+                ArtifactExportFormatResponse.from_export_format(export_format)
+                for export_format in self._artifacts.export_formats(artifact)
+            ],
+            metadata=artifact.metadata,
+        )
+
+    def _artifact_name(self, artifact: ArtifactObject) -> str:
+        for key in ("download_name", "source_name"):
+            value = artifact.metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        spec = self._artifact_types.get(
+            (artifact.artifact_type, artifact.schema_version)
+        )
+        if spec is not None:
+            return spec.title
+        return f"{artifact.artifact_type}@{artifact.schema_version}"
+
+
+__all__ = ["LibraryItem", "LibraryRun", "LibraryService"]

--- a/apps/api/src/grafy_api/v1/routes/library/views.py
+++ b/apps/api/src/grafy_api/v1/routes/library/views.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, HTTPException
+from grafy_core.domain.identity import WorkspaceCapability
+
+from grafy_api.services.errors import WorkbenchOperationError
+from grafy_api.v1.routes.auth.dependencies import require_workspace_capability
+
+from .dependencies import LibraryDependency
+from .models import (
+    LibraryItemResponse,
+    LibraryListResponse,
+    SaveRunArtifactRequest,
+    SaveUploadedArtifactRequest,
+)
+
+router = APIRouter(prefix="/workspaces/{workspace_id}/library", tags=["library"])
+
+
+def _unavailable(exc: WorkbenchOperationError) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/artifacts", response_model=LibraryListResponse)
+async def list_library_artifacts(
+    service: LibraryDependency,
+    access: require_workspace_capability(WorkspaceCapability.VIEW_ARTIFACTS),
+) -> LibraryListResponse:
+    return LibraryListResponse(items=await service.list_items(access.workspace_id))
+
+
+@router.post("/artifacts/from-run", response_model=LibraryItemResponse)
+async def save_library_artifact_from_run(
+    body: SaveRunArtifactRequest,
+    service: LibraryDependency,
+    access: require_workspace_capability(WorkspaceCapability.EDIT_GRAPH),
+) -> LibraryItemResponse:
+    try:
+        return await service.save_from_run(
+            workspace_id=access.workspace_id,
+            artifact_id=body.artifact_id,
+            execution_id=body.execution_id,
+            node_id=body.node_id,
+            node_title=body.node_title,
+        )
+    except WorkbenchOperationError as exc:
+        raise _unavailable(exc) from exc
+
+
+@router.post("/artifacts/from-upload", response_model=LibraryItemResponse)
+async def save_library_artifact_from_upload(
+    body: SaveUploadedArtifactRequest,
+    service: LibraryDependency,
+    access: require_workspace_capability(WorkspaceCapability.EDIT_GRAPH),
+) -> LibraryItemResponse:
+    return await service.save_uploaded(
+        workspace_id=access.workspace_id,
+        artifact_id=body.artifact_id,
+        original_filename=body.original_filename,
+    )
+
+
+__all__ = [
+    "list_library_artifacts",
+    "router",
+    "save_library_artifact_from_run",
+    "save_library_artifact_from_upload",
+]

--- a/apps/web/openapi/grafy.json
+++ b/apps/web/openapi/grafy.json
@@ -3192,6 +3192,189 @@
         "title": "InstantiateTemplateRequest",
         "type": "object"
       },
+      "LibraryItemResponse": {
+        "properties": {
+          "artifact": {
+            "$ref": "#/components/schemas/ArtifactSummaryResponse"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/LibraryProvenanceResponse"
+          },
+          "run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LibraryRunResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "artifact",
+          "name",
+          "provenance"
+        ],
+        "title": "LibraryItemResponse",
+        "type": "object"
+      },
+      "LibraryListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/LibraryItemResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "LibraryListResponse",
+        "type": "object"
+      },
+      "LibraryProvenanceResponse": {
+        "description": "The birth record frozen when the artifact entered the Library.",
+        "properties": {
+          "execution_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Graph Id"
+          },
+          "graph_revision": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Graph Revision"
+          },
+          "graph_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Graph Title"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Id"
+          },
+          "node_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Title"
+          },
+          "original_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Filename"
+          },
+          "saved_at": {
+            "format": "date-time",
+            "title": "Saved At",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "run",
+              "upload"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "saved_at"
+        ],
+        "title": "LibraryProvenanceResponse",
+        "type": "object"
+      },
+      "LibraryRunResponse": {
+        "description": "The retained run behind a run-sourced Library item.\n\nPresent only while execution history still holds the run, which is exactly\nwhen the item can link back to it.",
+        "properties": {
+          "execution_id": {
+            "format": "uuid",
+            "title": "Execution Id",
+            "type": "string"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "graph_id": {
+            "format": "uuid",
+            "title": "Graph Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "execution_id",
+          "graph_id"
+        ],
+        "title": "LibraryRunResponse",
+        "type": "object"
+      },
       "ModuleListResponse": {
         "properties": {
           "modules": {
@@ -5036,6 +5219,61 @@
           }
         },
         "title": "SampleRequest",
+        "type": "object"
+      },
+      "SaveRunArtifactRequest": {
+        "properties": {
+          "artifact_id": {
+            "format": "uuid",
+            "title": "Artifact Id",
+            "type": "string"
+          },
+          "execution_id": {
+            "format": "uuid",
+            "title": "Execution Id",
+            "type": "string"
+          },
+          "node_id": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Node Id",
+            "type": "string"
+          },
+          "node_title": {
+            "maxLength": 160,
+            "minLength": 1,
+            "title": "Node Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "execution_id",
+          "node_id",
+          "node_title"
+        ],
+        "title": "SaveRunArtifactRequest",
+        "type": "object"
+      },
+      "SaveUploadedArtifactRequest": {
+        "properties": {
+          "artifact_id": {
+            "format": "uuid",
+            "title": "Artifact Id",
+            "type": "string"
+          },
+          "original_filename": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Original Filename",
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "original_filename"
+        ],
+        "title": "SaveUploadedArtifactRequest",
         "type": "object"
       },
       "SavedGraphAnnotationLayout": {
@@ -11551,6 +11789,179 @@
         "summary": "Cancel Workspace Invitation",
         "tags": [
           "workspaces"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/library/artifacts": {
+      "get": {
+        "operationId": "list_library_artifacts_v1_workspaces__workspace_id__library_artifacts_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Library Artifacts",
+        "tags": [
+          "library"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/library/artifacts/from-run": {
+      "post": {
+        "operationId": "save_library_artifact_from_run_v1_workspaces__workspace_id__library_artifacts_from_run_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveRunArtifactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryItemResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Save Library Artifact From Run",
+        "tags": [
+          "library"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/library/artifacts/from-upload": {
+      "post": {
+        "operationId": "save_library_artifact_from_upload_v1_workspaces__workspace_id__library_artifacts_from_upload_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveUploadedArtifactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryItemResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Save Library Artifact From Upload",
+        "tags": [
+          "library"
         ]
       }
     },

--- a/apps/web/src/features/workbench/ui/LibraryDrawer.test.tsx
+++ b/apps/web/src/features/workbench/ui/LibraryDrawer.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LibraryDrawer } from "./LibraryDrawer";
+import type { LibraryItem } from "@/lib/api";
+
+const listLibraryArtifacts = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({ listLibraryArtifacts }));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+vi.mock("@stylexjs/stylex", () => ({
+  create: <Styles,>(styles: Styles) => styles,
+  props: () => ({}),
+}));
+
+const RUN_ITEM: LibraryItem = {
+  artifact: {
+    artifact_id: "artifact-run",
+    artifact_type: "table",
+    schema_version: 1,
+    content_type: "application/json",
+  },
+  name: "sales-table",
+  provenance: {
+    source: "run",
+    saved_at: "2026-09-11T12:00:00Z",
+    graph_id: "graph-1",
+    graph_title: "Sales",
+    node_id: "resize-1",
+    node_title: "Resize",
+    graph_revision: 4,
+    execution_id: "execution-1",
+  },
+  run: {
+    execution_id: "execution-1",
+    graph_id: "graph-1",
+    finished_at: "2026-09-11T11:59:00Z",
+  },
+};
+
+const UPLOAD_ITEM: LibraryItem = {
+  artifact: {
+    artifact_id: "artifact-upload",
+    artifact_type: "csv",
+    schema_version: 1,
+    content_type: "text/csv",
+  },
+  name: "measurements.csv",
+  provenance: {
+    source: "upload",
+    saved_at: "2026-09-11T12:00:00Z",
+    original_filename: "measurements.csv",
+  },
+  run: null,
+};
+
+describe("LibraryDrawer", () => {
+  const roots: ReturnType<typeof createRoot>[] = [];
+  let workspaceCounter = 0;
+
+  afterEach(() => {
+    React.act(() => {
+      for (const root of roots.splice(0)) root.unmount();
+    });
+    document.body.replaceChildren();
+    listLibraryArtifacts.mockReset();
+  });
+
+  async function render(items: LibraryItem[], onOpenRun = vi.fn()) {
+    listLibraryArtifacts.mockResolvedValue({ items });
+    workspaceCounter += 1;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await React.act(async () => {
+      root.render(
+        <LibraryDrawer
+          workspaceId={`workspace-${workspaceCounter}`}
+          onClose={vi.fn()}
+          onOpenRun={onOpenRun}
+        />,
+      );
+    });
+    return { container, onOpenRun };
+  }
+
+  it("writes the frozen graph, node, revision and run marker on the row", async () => {
+    const { container } = await render([RUN_ITEM]);
+
+    expect(container.textContent).toContain(
+      "Sales · Resize · revision 4 · from a run",
+    );
+  });
+
+  it("links a run-backed item back to its execution", async () => {
+    const { container, onOpenRun } = await render([RUN_ITEM]);
+
+    const row = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Sales · Resize"),
+    );
+    await React.act(async () => {
+      row!.click();
+    });
+
+    const link = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Open in execution history"),
+    );
+    expect(link).toBeDefined();
+    expect(container.textContent).toContain("run execution-1");
+
+    await React.act(async () => {
+      link!.click();
+    });
+
+    expect(onOpenRun).toHaveBeenCalledWith("graph-1", "execution-1");
+  });
+
+  it("marks an upload with its original filename and offers no run link", async () => {
+    const { container } = await render([UPLOAD_ITEM]);
+
+    expect(container.textContent).toContain("uploaded · measurements.csv");
+    await React.act(async () => {
+      [...container.querySelectorAll("button")]
+        .find((button) => button.textContent?.includes("uploaded ·"))!
+        .click();
+    });
+    expect(container.textContent).not.toContain("Open in execution history");
+  });
+
+  it("keeps the run link absent once the run is gone", async () => {
+    const { container } = await render([{ ...RUN_ITEM, run: null }]);
+
+    expect(container.textContent).toContain(
+      "Sales · Resize · revision 4 · from a run",
+    );
+    await React.act(async () => {
+      [...container.querySelectorAll("button")]
+        .find((button) => button.textContent?.includes("Sales · Resize"))!
+        .click();
+    });
+    expect(container.textContent).not.toContain("Open in execution history");
+  });
+
+  it("says the Library is empty before anything is saved", async () => {
+    const { container } = await render([]);
+
+    expect(container.textContent).toContain("Nothing in the Library yet");
+  });
+});

--- a/apps/web/src/features/workbench/ui/LibraryDrawer.tsx
+++ b/apps/web/src/features/workbench/ui/LibraryDrawer.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import * as React from "react";
+import * as stylex from "@stylexjs/stylex";
+import useSWR from "swr";
+import { ArrowUpRight, Library, LoaderCircle, X } from "lucide-react";
+
+import { listLibraryArtifacts, type LibraryItem } from "@/lib/api";
+
+const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace";
+
+const s = stylex.create({
+  drawer: {
+    position: "absolute",
+    zIndex: 35,
+    top: {
+      default: "66px",
+      "@media (max-width: 720px)": "12px",
+    },
+    right: {
+      default: "12px",
+      "@media (max-width: 720px)": "var(--grafy-mobile-drawer-right, 12px)",
+    },
+    bottom: {
+      default: "12px",
+      "@media (max-width: 720px)": "auto",
+    },
+    display: "flex",
+    flexDirection: "column",
+    width: { default: "380px", "@media (max-width: 720px)": "calc(100vw - 24px)" },
+    maxHeight: "min(620px, calc(100vh - 90px))",
+    overflow: "hidden",
+    backgroundColor: "#ffffff",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "#d7dbe0",
+    borderRadius: "10px",
+    boxShadow: "0 12px 34px rgba(15, 23, 42, 0.18)",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    padding: "10px 12px",
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: "#e8ebef",
+  },
+  title: {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    fontSize: "13px",
+    fontWeight: 600,
+    color: "#1f2937",
+  },
+  spacer: { flex: 1 },
+  close: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "24px",
+    height: "24px",
+    borderWidth: 0,
+    borderRadius: "6px",
+    backgroundColor: "transparent",
+    color: "#4b5563",
+    cursor: "pointer",
+    ":hover": { backgroundColor: "#f1f3f5" },
+  },
+  body: { display: "flex", flexDirection: "column", overflowY: "auto" },
+  empty: { padding: "22px 14px", fontSize: "13px", color: "#6b7280" },
+  row: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+    alignItems: "flex-start",
+    width: "100%",
+    padding: "9px 12px",
+    borderWidth: 0,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: "#f1f3f5",
+    backgroundColor: "transparent",
+    textAlign: "left",
+    cursor: "pointer",
+    ":hover": { backgroundColor: "#f8fafc" },
+  },
+  rowSelected: { backgroundColor: "#eef4ff" },
+  name: {
+    fontSize: "13px",
+    fontWeight: 500,
+    color: "#111827",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    maxWidth: "100%",
+  },
+  line: {
+    fontSize: "11.5px",
+    color: "#6b7280",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    maxWidth: "100%",
+  },
+  detail: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "6px",
+    padding: "12px",
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: "#e8ebef",
+    backgroundColor: "#fbfcfd",
+  },
+  detailLabel: {
+    fontSize: "10.5px",
+    fontWeight: 600,
+    letterSpacing: "0.04em",
+    textTransform: "uppercase",
+    color: "#6b7280",
+  },
+  detailValue: { fontSize: "12.5px", color: "#111827" },
+  detailMono: { fontFamily: MONO, fontSize: "11.5px", color: "#374151" },
+  runLink: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+    alignSelf: "flex-start",
+    marginTop: "2px",
+    padding: "4px 8px",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "#c7d2fe",
+    borderRadius: "6px",
+    backgroundColor: "#eef2ff",
+    color: "#3730a3",
+    fontSize: "12px",
+    cursor: "pointer",
+  },
+  loading: {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    padding: "18px 14px",
+    fontSize: "13px",
+    color: "#6b7280",
+  },
+});
+
+function provenanceLine(item: LibraryItem): string {
+  const { provenance } = item;
+  if (provenance.source === "upload") {
+    return provenance.original_filename
+      ? `uploaded · ${provenance.original_filename}`
+      : "uploaded";
+  }
+  const parts = [
+    provenance.graph_title,
+    provenance.node_title,
+    provenance.graph_revision == null
+      ? null
+      : `revision ${provenance.graph_revision}`,
+    "from a run",
+  ].filter((part): part is string => Boolean(part));
+  return parts.join(" · ");
+}
+
+export function LibraryDrawer({
+  workspaceId,
+  onClose,
+  onOpenRun,
+}: {
+  workspaceId: string;
+  onClose: () => void;
+  onOpenRun: (graphId: string, executionId: string) => void;
+}) {
+  const { data, isLoading } = useSWR(["library-artifacts", workspaceId], () =>
+    listLibraryArtifacts(workspaceId),
+  );
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const items = data?.items ?? [];
+  const selected = items.find((item) => item.artifact.artifact_id === selectedId);
+
+  return (
+    <section aria-label="Library" {...stylex.props(s.drawer)}>
+      <header {...stylex.props(s.header)}>
+        <span {...stylex.props(s.title)}>
+          <Library size={14} />
+          Library
+        </span>
+        <span {...stylex.props(s.spacer)} />
+        <button
+          type="button"
+          aria-label="Close Library"
+          onClick={onClose}
+          {...stylex.props(s.close)}
+        >
+          <X size={14} />
+        </button>
+      </header>
+      <div {...stylex.props(s.body)}>
+        {isLoading ? (
+          <span {...stylex.props(s.loading)}>
+            <LoaderCircle size={14} />
+            Loading…
+          </span>
+        ) : items.length === 0 ? (
+          <p {...stylex.props(s.empty)}>
+            Nothing in the Library yet. Save a Run artifact or upload a file to
+            record where it came from.
+          </p>
+        ) : (
+          items.map((item) => (
+            <button
+              key={item.artifact.artifact_id}
+              type="button"
+              aria-pressed={selectedId === item.artifact.artifact_id}
+              onClick={() => setSelectedId(item.artifact.artifact_id)}
+              {...stylex.props(
+                s.row,
+                selectedId === item.artifact.artifact_id && s.rowSelected,
+              )}
+            >
+              <span {...stylex.props(s.name)}>{item.name}</span>
+              <span {...stylex.props(s.line)}>{provenanceLine(item)}</span>
+            </button>
+          ))
+        )}
+      </div>
+      {selected ? (
+        <div {...stylex.props(s.detail)}>
+          <span {...stylex.props(s.detailLabel)}>Provenance</span>
+          <span {...stylex.props(s.detailValue)}>
+            {provenanceLine(selected)}
+          </span>
+          {selected.provenance.execution_id ? (
+            <span {...stylex.props(s.detailMono)}>
+              run {selected.provenance.execution_id}
+            </span>
+          ) : null}
+          {selected.run?.finished_at ? (
+            <span {...stylex.props(s.detailValue)}>
+              finished {new Date(selected.run.finished_at).toLocaleString()}
+            </span>
+          ) : null}
+          {selected.run ? (
+            <button
+              type="button"
+              {...stylex.props(s.runLink)}
+              onClick={() =>
+                onOpenRun(selected.run!.graph_id, selected.run!.execution_id)
+              }
+            >
+              <ArrowUpRight size={12} />
+              Open in execution history
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/workbench/ui/Workbench.tsx
+++ b/apps/web/src/features/workbench/ui/Workbench.tsx
@@ -18,6 +18,7 @@ import {
   type ReactFlowInstance,
 } from "@xyflow/react";
 import {
+  Bookmark,
   Circle,
   Copy,
   Eye,
@@ -36,6 +37,7 @@ import {
 } from "lucide-react";
 
 import { ExecutionHistoryDrawer } from "./ExecutionHistoryDrawer";
+import { LibraryDrawer } from "./LibraryDrawer";
 import { GraphRoomRecoveryNotice } from "./GraphRoomRecoveryNotice";
 import { GlobalIssueToastList, type GlobalIssue } from "./GlobalIssueToastList";
 import {
@@ -546,6 +548,7 @@ function WorkbenchBody({
     React.useState<ReactFlowInstance<CanvasNode, CanvasEdge>>();
   const { workspace } = useWorkspaceContext();
   const [libraryOpen, setLibraryOpen] = React.useState(false);
+  const [libraryDrawerOpen, setLibraryDrawerOpen] = React.useState(false);
   const [contextualDiscovery, setContextualDiscovery] =
     React.useState<ContextualDiscoverySession | null>(null);
   const [workspaceLibraryOpen, setWorkspaceLibraryOpen] = React.useState(false);
@@ -4235,6 +4238,21 @@ function WorkbenchBody({
           <History size={14} />
           <span {...stylex.props(s.railLabel)}>Runs</span>
         </button>
+        <button
+          type="button"
+          aria-label="Saved artifacts"
+          title="Saved artifacts and where they came from"
+          {...stylex.props(s.railButton, libraryDrawerOpen ? s.railPrimary : null)}
+          onClick={() => {
+            closeGraphBrowser();
+            setLibraryOpen(false);
+            setGridPanelOpen(false);
+            setLibraryDrawerOpen((open) => !open);
+          }}
+        >
+          <Bookmark size={14} />
+          <span {...stylex.props(s.railLabel)}>Saved</span>
+        </button>
         <span {...stylex.props(s.railDivider)} />
         <button
           type="button"
@@ -4289,6 +4307,22 @@ function WorkbenchBody({
           isDirty={isDirty}
           returnFocusRef={executionHistoryReturnFocusRef}
           onClose={() => setExecutionHistoryTarget(null)}
+        />
+      ) : null}
+
+      {libraryDrawerOpen ? (
+        <LibraryDrawer
+          workspaceId={workspaceId}
+          onClose={() => setLibraryDrawerOpen(false)}
+          onOpenRun={(graphId, executionId) => {
+            setLibraryDrawerOpen(false);
+            if (graphId !== activeGraph?.id) {
+              openGraphInNewTab(graphId);
+              return;
+            }
+            executionHistoryReturnFocusRef.current = null;
+            setExecutionHistoryTarget({ nodeId: null, executionId });
+          }}
         />
       ) : null}
 

--- a/apps/web/src/lib/api/contract.ts
+++ b/apps/web/src/lib/api/contract.ts
@@ -219,3 +219,11 @@ export type PortShape = Port["shape"];
 export type RunStatus = RunResponse["status"];
 export type NodeRunStatus = RunNodeResult["status"];
 export type JsonSchema = NodeSpec["config_schema"];
+
+export type LibraryProvenance = Schemas["LibraryProvenanceResponse"];
+export type LibraryRun = Schemas["LibraryRunResponse"];
+export type LibraryItem = Schemas["LibraryItemResponse"];
+export type LibraryList = Schemas["LibraryListResponse"];
+export type SaveRunArtifactRequest = Schemas["SaveRunArtifactRequest"];
+export type SaveUploadedArtifactRequest =
+  Schemas["SaveUploadedArtifactRequest"];

--- a/apps/web/src/lib/api/generated/grafy.ts
+++ b/apps/web/src/lib/api/generated/grafy.ts
@@ -799,6 +799,57 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/v1/workspaces/{workspace_id}/library/artifacts": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List Library Artifacts */
+        readonly get: operations["list_library_artifacts_v1_workspaces__workspace_id__library_artifacts_get"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/workspaces/{workspace_id}/library/artifacts/from-run": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Save Library Artifact From Run */
+        readonly post: operations["save_library_artifact_from_run_v1_workspaces__workspace_id__library_artifacts_from_run_post"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/v1/workspaces/{workspace_id}/library/artifacts/from-upload": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Save Library Artifact From Upload */
+        readonly post: operations["save_library_artifact_from_upload_v1_workspaces__workspace_id__library_artifacts_from_upload_post"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/v1/workspaces/{workspace_id}/members": {
         readonly parameters: {
             readonly query?: never;
@@ -2258,6 +2309,70 @@ export interface components {
             /** Name */
             readonly name: string;
         };
+        /** LibraryItemResponse */
+        readonly LibraryItemResponse: {
+            readonly artifact: components["schemas"]["ArtifactSummaryResponse"];
+            /** Name */
+            readonly name: string;
+            readonly provenance: components["schemas"]["LibraryProvenanceResponse"];
+            readonly run?: components["schemas"]["LibraryRunResponse"] | null;
+        };
+        /** LibraryListResponse */
+        readonly LibraryListResponse: {
+            /** Items */
+            readonly items: readonly components["schemas"]["LibraryItemResponse"][];
+        };
+        /**
+         * LibraryProvenanceResponse
+         * @description The birth record frozen when the artifact entered the Library.
+         */
+        readonly LibraryProvenanceResponse: {
+            /** Execution Id */
+            readonly execution_id?: string | null;
+            /** Graph Id */
+            readonly graph_id?: string | null;
+            /** Graph Revision */
+            readonly graph_revision?: number | null;
+            /** Graph Title */
+            readonly graph_title?: string | null;
+            /** Node Id */
+            readonly node_id?: string | null;
+            /** Node Title */
+            readonly node_title?: string | null;
+            /** Original Filename */
+            readonly original_filename?: string | null;
+            /**
+             * Saved At
+             * Format: date-time
+             */
+            readonly saved_at: string;
+            /**
+             * Source
+             * @enum {string}
+             */
+            readonly source: "run" | "upload";
+        };
+        /**
+         * LibraryRunResponse
+         * @description The retained run behind a run-sourced Library item.
+         *
+         *     Present only while execution history still holds the run, which is exactly
+         *     when the item can link back to it.
+         */
+        readonly LibraryRunResponse: {
+            /**
+             * Execution Id
+             * Format: uuid
+             */
+            readonly execution_id: string;
+            /** Finished At */
+            readonly finished_at?: string | null;
+            /**
+             * Graph Id
+             * Format: uuid
+             */
+            readonly graph_id: string;
+        };
         /** ModuleListResponse */
         readonly ModuleListResponse: {
             /** Modules */
@@ -3204,6 +3319,33 @@ export interface components {
              * Format: date-time
              */
             readonly updated_at: string;
+        };
+        /** SaveRunArtifactRequest */
+        readonly SaveRunArtifactRequest: {
+            /**
+             * Artifact Id
+             * Format: uuid
+             */
+            readonly artifact_id: string;
+            /**
+             * Execution Id
+             * Format: uuid
+             */
+            readonly execution_id: string;
+            /** Node Id */
+            readonly node_id: string;
+            /** Node Title */
+            readonly node_title: string;
+        };
+        /** SaveUploadedArtifactRequest */
+        readonly SaveUploadedArtifactRequest: {
+            /**
+             * Artifact Id
+             * Format: uuid
+             */
+            readonly artifact_id: string;
+            /** Original Filename */
+            readonly original_filename: string;
         };
         /** SessionResponse */
         readonly SessionResponse: {
@@ -6012,6 +6154,107 @@ export interface operations {
                     readonly [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            readonly 422: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    readonly list_library_artifacts_v1_workspaces__workspace_id__library_artifacts_get: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly workspace_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description Successful Response */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["LibraryListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            readonly 422: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    readonly save_library_artifact_from_run_v1_workspaces__workspace_id__library_artifacts_from_run_post: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly workspace_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["SaveRunArtifactRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Successful Response */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["LibraryItemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            readonly 422: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    readonly save_library_artifact_from_upload_v1_workspaces__workspace_id__library_artifacts_from_upload_post: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly workspace_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["SaveUploadedArtifactRequest"];
+            };
+        };
+        readonly responses: {
+            /** @description Successful Response */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["LibraryItemResponse"];
+                };
             };
             /** @description Validation Error */
             readonly 422: {

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -4,3 +4,4 @@ export * from "./workbench";
 export * from "./workspaces";
 export * from "./modules";
 export * from "./templates";
+export * from "./library";

--- a/apps/web/src/lib/api/library.ts
+++ b/apps/web/src/lib/api/library.ts
@@ -1,0 +1,33 @@
+import { request } from "./client";
+import type {
+  LibraryItem,
+  LibraryList,
+  SaveRunArtifactRequest,
+  SaveUploadedArtifactRequest,
+} from "./contract";
+
+function libraryPath(workspaceId: string, suffix = ""): string {
+  return `/v1/workspaces/${encodeURIComponent(workspaceId)}/library/artifacts${suffix}`;
+}
+
+export function listLibraryArtifacts(workspaceId: string) {
+  return request<LibraryList>("GET", libraryPath(workspaceId));
+}
+
+export function saveRunArtifactToLibrary(
+  workspaceId: string,
+  body: SaveRunArtifactRequest,
+) {
+  return request<LibraryItem>("POST", libraryPath(workspaceId, "/from-run"), {
+    body,
+  });
+}
+
+export function saveUploadedArtifactToLibrary(
+  workspaceId: string,
+  body: SaveUploadedArtifactRequest,
+) {
+  return request<LibraryItem>("POST", libraryPath(workspaceId, "/from-upload"), {
+    body,
+  });
+}

--- a/infra/db/migrations/versions/0028_library_provenance.py
+++ b/infra/db/migrations/versions/0028_library_provenance.py
@@ -1,0 +1,30 @@
+"""Record how a Library artifact came to be.
+
+Only the Library provenance snapshot is added here. The Library placement
+columns from #25 (folder tree, saved-by) do not exist yet, so a non-null
+``library_provenance`` is the whole marker that an artifact is in the Library.
+
+Revision ID: 0028_library_provenance
+Revises: 0027_transient_executions
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0028_library_provenance"
+down_revision: str | Sequence[str] | None = "0027_transient_executions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "artifact_objects",
+        sa.Column("library_provenance", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("artifact_objects", "library_provenance")

--- a/libs/core/src/grafy_core/artifacts.py
+++ b/libs/core/src/grafy_core/artifacts.py
@@ -1,15 +1,16 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
+    Any,
     Literal,
     Self,
     TypeAlias,
-    Any,
-    Callable,
 )
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 if TYPE_CHECKING:
     from grafy_core.plugins import PluginRuntimeContext
@@ -210,6 +211,144 @@ class ArtifactRefSequence(BaseModel):
         return self
 
 
+type LibrarySource = Literal["run", "upload"]
+
+_GRAPH_TITLE_MAX_LENGTH = 160
+_NODE_TITLE_MAX_LENGTH = 160
+_NODE_ID_MAX_LENGTH = 255
+_FILENAME_MAX_LENGTH = 255
+
+
+def _required_text(value: str, *, label: str, max_length: int) -> str:
+    text = value.strip()
+    if text == "":
+        raise ValueError(f"Library provenance {label} must not be blank")
+    if len(text) > max_length:
+        raise ValueError(
+            f"Library provenance {label} must be at most {max_length} characters"
+        )
+    return text
+
+
+class LibraryProvenance(BaseModel):
+    """Birth record written once when an artifact enters a Workspace Library.
+
+    The run facts are a snapshot of the save gesture: the graph and node titles
+    are frozen here so later renames, replacements, or deletions of the source
+    never rewrite this row. Nothing in the record is resolved live.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source: LibrarySource
+    saved_at: datetime
+    graph_id: UUID | None = None
+    graph_title: str | None = None
+    node_id: str | None = None
+    node_title: str | None = None
+    graph_revision: int | None = None
+    execution_id: UUID | None = None
+    original_filename: str | None = None
+
+    @field_validator("saved_at")
+    @classmethod
+    def require_aware_saved_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("Library provenance save time must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def validate_source_shape(self) -> Self:
+        if self.source == "run":
+            missing = [
+                label
+                for label, value in (
+                    ("graph id", self.graph_id),
+                    ("graph title", self.graph_title),
+                    ("node id", self.node_id),
+                    ("node title", self.node_title),
+                    ("graph revision", self.graph_revision),
+                    ("execution id", self.execution_id),
+                )
+                if value is None
+            ]
+            if missing:
+                raise ValueError(
+                    "A run Library provenance requires " + ", ".join(missing)
+                )
+            if self.graph_revision is not None and self.graph_revision < 1:
+                raise ValueError("Library provenance graph revision must be positive")
+            if self.original_filename is not None:
+                raise ValueError(
+                    "A run Library provenance cannot carry an uploaded filename"
+                )
+            return self
+        if self.original_filename is None:
+            raise ValueError("An uploaded Library provenance requires a filename")
+        if any(
+            value is not None
+            for value in (
+                self.graph_id,
+                self.graph_title,
+                self.node_id,
+                self.node_title,
+                self.graph_revision,
+                self.execution_id,
+            )
+        ):
+            raise ValueError(
+                "An uploaded Library provenance cannot carry run facts"
+            )
+        return self
+
+    @classmethod
+    def from_run(
+        cls,
+        *,
+        saved_at: datetime,
+        graph_id: UUID,
+        graph_title: str,
+        node_id: str,
+        node_title: str,
+        graph_revision: int,
+        execution_id: UUID,
+    ) -> Self:
+        return cls(
+            source="run",
+            saved_at=saved_at,
+            graph_id=graph_id,
+            graph_title=_required_text(
+                graph_title,
+                label="graph title",
+                max_length=_GRAPH_TITLE_MAX_LENGTH,
+            ),
+            node_id=_required_text(
+                node_id,
+                label="node id",
+                max_length=_NODE_ID_MAX_LENGTH,
+            ),
+            node_title=_required_text(
+                node_title,
+                label="node title",
+                max_length=_NODE_TITLE_MAX_LENGTH,
+            ),
+            graph_revision=graph_revision,
+            execution_id=execution_id,
+        )
+
+    @classmethod
+    def from_upload(cls, *, saved_at: datetime, original_filename: str) -> Self:
+        return cls(
+            source="upload",
+            saved_at=saved_at,
+            original_filename=_required_text(
+                original_filename,
+                label="original filename",
+                max_length=_FILENAME_MAX_LENGTH,
+            ),
+        )
+
+
 @dataclass
 class ArtifactObject:
     workspace_id: UUID
@@ -224,6 +363,7 @@ class ArtifactObject:
     byte_size: int | None = None
     sha256: str | None = None
     metadata: JsonObject = field(default_factory=dict)
+    library_provenance: LibraryProvenance | None = None
 
     def ref(self) -> ArtifactRef:
         return ArtifactRef.from_key(
@@ -236,16 +376,29 @@ class ArtifactObject:
 if TYPE_CHECKING:
     from grafy_core.ports.artifacts import (
         ArtifactRepositoryPort as ArtifactRepositoryPort,
+    )
+    from grafy_core.ports.artifacts import (
         UnitOfWorkPort as UnitOfWorkPort,
     )
-
     from grafy_core.runtime.in_memory import (
         InMemoryArtifactRepository as InMemoryArtifactRepository,
+    )
+    from grafy_core.runtime.in_memory import (
         InMemoryDataStore as InMemoryDataStore,
+    )
+    from grafy_core.runtime.in_memory import (
         InMemoryGraphExecutionHistoryRepository as InMemoryGraphExecutionHistoryRepository,
+    )
+    from grafy_core.runtime.in_memory import (
         InMemoryInvocationCacheRepository as InMemoryInvocationCacheRepository,
+    )
+    from grafy_core.runtime.in_memory import (
         InMemoryMaterializedNodeOutputsRepository as InMemoryMaterializedNodeOutputsRepository,
+    )
+    from grafy_core.runtime.in_memory import (
         InMemoryStagedUploadRepository as InMemoryStagedUploadRepository,
+    )
+    from grafy_core.runtime.in_memory import (
         InMemoryUnitOfWork as InMemoryUnitOfWork,
     )
 

--- a/libs/core/src/grafy_core/ports/artifacts.py
+++ b/libs/core/src/grafy_core/ports/artifacts.py
@@ -29,6 +29,8 @@ class ArtifactRepositoryPort(Protocol):
         key: ArtifactTypeKey,
     ) -> list[ArtifactObject]: ...
 
+    async def list_library(self, workspace_id: UUID) -> list[ArtifactObject]: ...
+
 
 class UnitOfWorkPort(TransactionPort, Protocol):
     @property

--- a/libs/core/src/grafy_core/runtime/in_memory.py
+++ b/libs/core/src/grafy_core/runtime/in_memory.py
@@ -14,7 +14,6 @@ from typing import (
 from uuid import UUID
 
 if TYPE_CHECKING:
-    from grafy_core.domain.invocation_cache import InvocationCacheEntry
     from grafy_core.domain.execution_history import (
         GraphExecution,
         GraphExecutionCursor,
@@ -23,25 +22,26 @@ if TYPE_CHECKING:
         GraphExecutionPage,
         GraphExecutionStatus,
     )
+    from grafy_core.domain.invocation_cache import InvocationCacheEntry
     from grafy_core.domain.materialized_outputs import MaterializedNodeOutputs
     from grafy_core.domain.staged_uploads import StagedUpload
-    from grafy_core.ports.invocation_cache import InvocationCacheRepositoryPort
     from grafy_core.ports.execution_history import (
         GraphExecutionHistoryRepositoryPort,
     )
+    from grafy_core.ports.invocation_cache import InvocationCacheRepositoryPort
     from grafy_core.ports.materialized_outputs import (
         MaterializedNodeOutputsRepositoryPort,
     )
     from grafy_core.ports.staged_uploads import StagedUploadRepositoryPort
 
 from grafy_core.artifacts import ArtifactObject, ArtifactTypeKey
-from grafy_core.ports.artifacts import ArtifactRepositoryPort, UnitOfWorkPort
-from grafy_core.domain.execution_history import TransientExecution
 from grafy_core.domain.errors import (
     CollaborationActiveExecutionError,
     NotFoundError,
     ObjectAlreadyExistsError,
 )
+from grafy_core.domain.execution_history import TransientExecution
+from grafy_core.ports.artifacts import ArtifactRepositoryPort, UnitOfWorkPort
 
 
 def _clone[T](value: T) -> T:
@@ -139,6 +139,15 @@ class InMemoryArtifactRepository(ArtifactRepositoryPort):
             if artifact.workspace_id == workspace_id
             and artifact.artifact_type == key.id
             and artifact.schema_version == key.schema_version
+        ]
+
+    @override
+    async def list_library(self, workspace_id: UUID) -> list[ArtifactObject]:
+        return [
+            artifact
+            for artifact in self._store.artifacts.values()
+            if artifact.workspace_id == workspace_id
+            and artifact.library_provenance is not None
         ]
 
 

--- a/libs/persistence/src/grafy_persistence/adapters/repositories/artifacts.py
+++ b/libs/persistence/src/grafy_persistence/adapters/repositories/artifacts.py
@@ -1,15 +1,17 @@
 from collections.abc import Collection
 from typing import override
 from uuid import UUID
+
+from grafy_core.artifacts import ArtifactObject, ArtifactTypeKey
+from grafy_core.domain.staged_uploads import StagedUpload
+from grafy_core.ports.artifacts import ArtifactRepositoryPort
+from grafy_core.ports.staged_uploads import StagedUploadRepositoryPort
 from sqlalchemy import (
     delete,
     select,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
-from grafy_core.artifacts import ArtifactObject, ArtifactTypeKey
-from grafy_core.ports.artifacts import ArtifactRepositoryPort
-from grafy_core.domain.staged_uploads import StagedUpload
-from grafy_core.ports.staged_uploads import StagedUploadRepositoryPort
+
 from grafy_persistence import schema
 
 
@@ -71,6 +73,18 @@ class SqlArtifactRepository(ArtifactRepositoryPort):
                 schema.artifact_objects.c.artifact_type == key.id,
                 schema.artifact_objects.c.schema_version == key.schema_version,
                 schema.artifact_objects.c.workspace_id == workspace_id,
+            )
+            .order_by(schema.artifact_objects.c.id.asc())
+        )
+        return list(result)
+
+    @override
+    async def list_library(self, workspace_id: UUID) -> list[ArtifactObject]:
+        result = await self._session.scalars(
+            select(ArtifactObject)
+            .where(
+                schema.artifact_objects.c.workspace_id == workspace_id,
+                schema.artifact_objects.c.library_provenance.is_not(None),
             )
             .order_by(schema.artifact_objects.c.id.asc())
         )

--- a/libs/persistence/src/grafy_persistence/column_types.py
+++ b/libs/persistence/src/grafy_persistence/column_types.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from enum import StrEnum
 
+from grafy_core.artifacts import LibraryProvenance
 from grafy_core.domain.artifact_outputs import (
     ArtifactOutputValue,
     artifact_outputs_from_storage,
@@ -117,4 +118,13 @@ class ArtifactOutputsType(
 
 class SavedGraphDocumentType(PydanticJSONType[SavedGraphDocument]):
     model_type = SavedGraphDocument
+    cache_ok = True
+
+
+class LibraryProvenanceType(PydanticJSONType[LibraryProvenance]):
+    # Absent provenance must be SQL NULL. The JSON impl otherwise stores Python
+    # None as the JSON literal `null`, which would make every artifact look like
+    # a Library item to `library_provenance IS NOT NULL`.
+    impl = JSON(none_as_null=True)
+    model_type = LibraryProvenance
     cache_ok = True

--- a/libs/persistence/src/grafy_persistence/schema/artifacts.py
+++ b/libs/persistence/src/grafy_persistence/schema/artifacts.py
@@ -13,7 +13,10 @@ from sqlalchemy import (
 )
 from sqlalchemy import Uuid as SaUuid
 
-from grafy_persistence.column_types import UTCDateTime
+from grafy_persistence.column_types import (
+    LibraryProvenanceType,
+    UTCDateTime,
+)
 
 from .base import metadata
 
@@ -37,6 +40,7 @@ artifact_objects = Table(
     Column("byte_size", BigInteger, nullable=True),
     Column("sha256", String(64), nullable=True),
     Column("metadata", JSON, nullable=False),
+    Column("library_provenance", LibraryProvenanceType(), nullable=True),
     UniqueConstraint("workspace_id", "id", name="uq_artifact_objects_workspace_id_id"),
     Index(
         "ix_artifact_objects_workspace_type",

--- a/tests/integration/library/test_library_routes.py
+++ b/tests/integration/library/test_library_routes.py
@@ -1,0 +1,55 @@
+"""HTTP wiring for the Library artifact endpoints."""
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from tests.support.identity import WORKSPACE_ID
+
+
+def _library_path(suffix: str = "") -> str:
+    return f"/v1/workspaces/{WORKSPACE_ID}/library{suffix}"
+
+
+def test_library_is_empty_before_anything_is_saved(builtin_client: TestClient) -> None:
+    response = builtin_client.get(_library_path("/artifacts"))
+
+    assert response.status_code == 200
+    assert response.json() == {"items": []}
+
+
+def test_saving_an_unknown_artifact_is_not_found(builtin_client: TestClient) -> None:
+    response = builtin_client.post(
+        _library_path("/artifacts/from-upload"),
+        json={"artifact_id": str(uuid4()), "original_filename": "measurements.csv"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_saving_from_an_unknown_run_is_not_found(builtin_client: TestClient) -> None:
+    response = builtin_client.post(
+        _library_path("/artifacts/from-run"),
+        json={
+            "artifact_id": str(uuid4()),
+            "execution_id": str(uuid4()),
+            "node_id": "resize-1",
+            "node_title": "Resize",
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_a_save_request_must_name_a_node_and_title(builtin_client: TestClient) -> None:
+    response = builtin_client.post(
+        _library_path("/artifacts/from-run"),
+        json={
+            "artifact_id": str(uuid4()),
+            "execution_id": str(uuid4()),
+            "node_id": "   ",
+            "node_title": "Resize",
+        },
+    )
+
+    assert response.status_code == 422

--- a/tests/integration/ops/test_openapi.py
+++ b/tests/integration/ops/test_openapi.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 from fastapi.routing import APIRoute
+from grafy_api.settings import Settings
 from pydantic import SecretStr
 
-from grafy_api.settings import Settings
 from tests.testkit import app_with_overrides, client_with_overrides, create_db_url, db
 
 
@@ -57,6 +57,9 @@ def test_openapi_contains_exact_public_routes(settings: Settings) -> None:
         "/v1/workspaces/{workspace_id}/graphs/{graph_id}/nodes/{node_id}/secrets/{name}",
         "/v1/workspaces/{workspace_id}/graphs/{graph_id}/opened",
         "/v1/workspaces/{workspace_id}/graphs/{graph_id}/star",
+        "/v1/workspaces/{workspace_id}/library/artifacts",
+        "/v1/workspaces/{workspace_id}/library/artifacts/from-run",
+        "/v1/workspaces/{workspace_id}/library/artifacts/from-upload",
         "/v1/workspaces/{workspace_id}/modules",
         "/v1/workspaces/{workspace_id}/modules/import",
         "/v1/workspaces/{workspace_id}/modules/publish",

--- a/tests/support/workbench.py
+++ b/tests/support/workbench.py
@@ -5,8 +5,8 @@ from grafy_api.v1.routes.artifacts.dependencies import artifact_service
 from grafy_api.v1.routes.auth.dependencies import browser_actor, workspace_actor
 from grafy_api.v1.routes.catalog.dependencies import (
     graph_module_executor,
-    plugin_release_service,
     plugin_registry,
+    plugin_release_service,
 )
 from grafy_api.v1.routes.executions.dependencies import (
     execution_admission_limiter,
@@ -15,9 +15,9 @@ from grafy_api.v1.routes.executions.dependencies import (
     run_execution_manager,
     run_result_presenter,
 )
-from grafy_api.v1.routes.uploads.dependencies import staged_upload_service
-
+from grafy_api.v1.routes.library.dependencies import library_service
 from grafy_api.v1.routes.modules.dependencies import module_library_service
+from grafy_api.v1.routes.uploads.dependencies import staged_upload_service
 
 from tests.support.identity import browser_actor_override
 from tests.testkit import AppDependency, DependencyOverride
@@ -37,6 +37,7 @@ def workbench_dependency_overrides(
         materialization_service: lambda: components.materializations,
         run_result_presenter: lambda: components.presenter,
         artifact_service: lambda: components.artifacts,
+        library_service: lambda: components.library,
         plugin_release_service: lambda: components.plugin_releases,
         graph_module_executor: lambda: components.run_graph,
         browser_actor: browser_actor_override,

--- a/tests/unit/api/services/test_library_service.py
+++ b/tests/unit/api/services/test_library_service.py
@@ -1,0 +1,346 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from grafy_api.artifact_availability import ArtifactAvailability
+from grafy_api.services.errors import WorkbenchOperationError
+from grafy_api.v1.routes.artifacts.services import ArtifactService
+from grafy_api.v1.routes.library.services import LibraryService
+from grafy_core.application.saved_graphs import SavedGraphService
+from grafy_core.artifacts import ArtifactObject
+from grafy_core.domain.errors import NotFoundError
+from grafy_core.domain.execution_history import (
+    GraphExecution,
+    GraphExecutionNodeResult,
+)
+from grafy_core.runtime.in_memory import InMemoryDataStore, InMemoryUnitOfWork
+from grafy_storage import LocalFileObjectStore
+
+WORKSPACE_ID = UUID("00000000-0000-0000-0000-000000000007")
+NOW = datetime(2026, 9, 11, 12, 0, tzinfo=UTC)
+
+
+@dataclass
+class FakeGraph:
+    name: str
+
+
+class FakeSavedGraphs:
+    """A saved graph service whose titles can be changed or deleted at will."""
+
+    def __init__(self) -> None:
+        self.names: dict[UUID, str] = {}
+
+    def set_title(self, graph_id: UUID, name: str) -> None:
+        self.names[graph_id] = name
+
+    def delete(self, graph_id: UUID) -> None:
+        self.names.pop(graph_id, None)
+
+    async def get(self, workspace_id: UUID, graph_id: UUID) -> FakeGraph:
+        del workspace_id
+        name = self.names.get(graph_id)
+        if name is None:
+            raise NotFoundError("Saved graph", str(graph_id))
+        return FakeGraph(name)
+
+
+@dataclass(frozen=True)
+class Seeded:
+    artifact_id: UUID
+    graph_id: UUID
+    execution_id: UUID
+    node_id: str
+
+
+def _service(
+    store: InMemoryDataStore,
+    saved_graphs: FakeSavedGraphs,
+    tmp_path: Path,
+) -> tuple[LibraryService, ArtifactService]:
+    unit_of_work = InMemoryUnitOfWork(store)
+    storage = LocalFileObjectStore(tmp_path / "objects")
+    availability = ArtifactAvailability(unit_of_work, storage)
+    artifacts = ArtifactService(
+        unit_of_work,
+        storage,
+        {},
+        availability=availability,
+    )
+    service = LibraryService(
+        unit_of_work,
+        artifacts,
+        {},
+        saved_graphs=cast(SavedGraphService, saved_graphs),
+    )
+    return service, artifacts
+
+
+async def _seed_run(
+    store: InMemoryDataStore,
+    *,
+    graph_title: str = "Sales",
+    node_id: str = "resize-1",
+    revision: int = 4,
+) -> Seeded:
+    artifact_id = uuid4()
+    graph_id = uuid4()
+    execution_id = uuid4()
+    artifact = ArtifactObject(
+        workspace_id=WORKSPACE_ID,
+        artifact_type="text.plain",
+        schema_version=1,
+        content_type="application/json",
+        id=artifact_id,
+        inline_payload={"text": "hello"},
+        metadata={"download_name": "report.json"},
+    )
+    execution = GraphExecution(
+        workspace_id=WORKSPACE_ID,
+        execution_id=execution_id,
+        graph_id=graph_id,
+        graph_revision=revision,
+        status="succeeded",
+        requested_node_ids=(node_id,),
+        created_at=NOW,
+        started_at=NOW,
+        finished_at=NOW,
+    )
+    result = GraphExecutionNodeResult(
+        workspace_id=WORKSPACE_ID,
+        execution_id=execution_id,
+        node_id=node_id,
+        position=0,
+        status="succeeded",
+        outputs={"result": artifact.ref()},
+        completed_at=NOW,
+    )
+    unit_of_work = InMemoryUnitOfWork(store)
+    async with unit_of_work as entered:
+        await entered.artifacts.add(artifact)
+        await entered.commit()
+    async with unit_of_work as entered:
+        await entered.execution_history.add(execution)
+        await entered.execution_history.add_node_result(result)
+        await entered.commit()
+    return Seeded(
+        artifact_id=artifact_id,
+        graph_id=graph_id,
+        execution_id=execution_id,
+        node_id=node_id,
+    )
+
+
+async def _seed_uploaded(store: InMemoryDataStore) -> UUID:
+    artifact_id = uuid4()
+    artifact = ArtifactObject(
+        workspace_id=WORKSPACE_ID,
+        artifact_type="file.csv",
+        schema_version=1,
+        content_type="text/csv",
+        id=artifact_id,
+        metadata={"download_name": "measurements.csv"},
+    )
+    unit_of_work = InMemoryUnitOfWork(store)
+    async with unit_of_work as entered:
+        await entered.artifacts.add(artifact)
+        await entered.commit()
+    return artifact_id
+
+
+async def _save_run(
+    service: LibraryService,
+    seeded: Seeded,
+    *,
+    node_title: str = "Resize",
+) -> None:
+    _ = await service.save_from_run(
+        workspace_id=WORKSPACE_ID,
+        artifact_id=seeded.artifact_id,
+        execution_id=seeded.execution_id,
+        node_id=seeded.node_id,
+        node_title=node_title,
+    )
+
+
+@pytest.mark.asyncio
+async def test_saving_a_run_artifact_writes_the_four_producing_facts(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryDataStore()
+    seeded = await _seed_run(store)
+    saved_graphs = FakeSavedGraphs()
+    saved_graphs.set_title(seeded.graph_id, "Sales")
+    service, artifacts = _service(store, saved_graphs, tmp_path)
+    try:
+        await _save_run(service, seeded)
+        items = await service.list_items(WORKSPACE_ID)
+    finally:
+        await artifacts.close()
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.artifact.artifact_id == seeded.artifact_id
+    assert item.provenance.source == "run"
+    assert item.provenance.graph_id == seeded.graph_id
+    assert item.provenance.graph_title == "Sales"
+    assert item.provenance.node_id == seeded.node_id
+    assert item.provenance.node_title == "Resize"
+    assert item.provenance.graph_revision == 4
+    assert item.provenance.execution_id == seeded.execution_id
+    assert item.provenance.original_filename is None
+    # The detail record carries the run id, its finish time, and the run link.
+    assert item.run is not None
+    assert item.run.execution_id == seeded.execution_id
+    assert item.run.graph_id == seeded.graph_id
+    assert item.run.finished_at == NOW
+
+
+@pytest.mark.asyncio
+async def test_renaming_or_deleting_the_producing_graph_leaves_the_line(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryDataStore()
+    seeded = await _seed_run(store)
+    saved_graphs = FakeSavedGraphs()
+    saved_graphs.set_title(seeded.graph_id, "Sales")
+    service, artifacts = _service(store, saved_graphs, tmp_path)
+    try:
+        await _save_run(service, seeded)
+
+        saved_graphs.set_title(seeded.graph_id, "Renamed after the save")
+        renamed = (await service.list_items(WORKSPACE_ID))[0]
+        assert renamed.provenance.graph_title == "Sales"
+
+        saved_graphs.delete(seeded.graph_id)
+        deleted = (await service.list_items(WORKSPACE_ID))[0]
+        assert deleted.provenance.graph_title == "Sales"
+        assert deleted.provenance.node_title == "Resize"
+        assert deleted.provenance.graph_revision == 4
+    finally:
+        await artifacts.close()
+
+
+@pytest.mark.asyncio
+async def test_saving_again_never_rewrites_the_birth_record(tmp_path: Path) -> None:
+    store = InMemoryDataStore()
+    seeded = await _seed_run(store)
+    saved_graphs = FakeSavedGraphs()
+    saved_graphs.set_title(seeded.graph_id, "Sales")
+    service, artifacts = _service(store, saved_graphs, tmp_path)
+    try:
+        await _save_run(service, seeded)
+        saved_graphs.set_title(seeded.graph_id, "Renamed")
+
+        _ = await service.save_from_run(
+            workspace_id=WORKSPACE_ID,
+            artifact_id=seeded.artifact_id,
+            execution_id=seeded.execution_id,
+            node_id=seeded.node_id,
+            node_title="A different title",
+        )
+        item = (await service.list_items(WORKSPACE_ID))[0]
+    finally:
+        await artifacts.close()
+
+    assert item.provenance.graph_title == "Sales"
+    assert item.provenance.node_title == "Resize"
+
+
+@pytest.mark.asyncio
+async def test_run_link_is_absent_once_the_run_is_gone(tmp_path: Path) -> None:
+    store = InMemoryDataStore()
+    seeded = await _seed_run(store)
+    saved_graphs = FakeSavedGraphs()
+    saved_graphs.set_title(seeded.graph_id, "Sales")
+    service, artifacts = _service(store, saved_graphs, tmp_path)
+    try:
+        await _save_run(service, seeded)
+        assert (await service.list_items(WORKSPACE_ID))[0].run is not None
+
+        store.graph_executions.pop(seeded.execution_id)
+        item = (await service.list_items(WORKSPACE_ID))[0]
+    finally:
+        await artifacts.close()
+
+    assert item.run is None
+    # The recorded run identity stays; only the live run link goes away.
+    assert item.provenance.execution_id == seeded.execution_id
+
+
+@pytest.mark.asyncio
+async def test_an_uploaded_artifact_shows_the_filename_and_no_run_link(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryDataStore()
+    artifact_id = await _seed_uploaded(store)
+    service, artifacts = _service(store, FakeSavedGraphs(), tmp_path)
+    try:
+        saved = await service.save_uploaded(
+            workspace_id=WORKSPACE_ID,
+            artifact_id=artifact_id,
+            original_filename="measurements.csv",
+        )
+        item = (await service.list_items(WORKSPACE_ID))[0]
+    finally:
+        await artifacts.close()
+
+    assert saved.provenance.source == "upload"
+    assert item.provenance.source == "upload"
+    assert item.provenance.original_filename == "measurements.csv"
+    assert item.provenance.graph_title is None
+    assert item.provenance.node_title is None
+    assert item.provenance.graph_revision is None
+    assert item.provenance.execution_id is None
+    assert item.run is None
+
+
+@pytest.mark.asyncio
+async def test_a_run_artifact_must_belong_to_the_named_node_and_run(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryDataStore()
+    seeded = await _seed_run(store)
+    saved_graphs = FakeSavedGraphs()
+    saved_graphs.set_title(seeded.graph_id, "Sales")
+    service, artifacts = _service(store, saved_graphs, tmp_path)
+    try:
+        with pytest.raises(WorkbenchOperationError):
+            _ = await service.save_from_run(
+                workspace_id=WORKSPACE_ID,
+                artifact_id=seeded.artifact_id,
+                execution_id=seeded.execution_id,
+                node_id="some-other-node",
+                node_title="Other",
+            )
+        with pytest.raises(NotFoundError):
+            _ = await service.save_from_run(
+                workspace_id=WORKSPACE_ID,
+                artifact_id=seeded.artifact_id,
+                execution_id=uuid4(),
+                node_id=seeded.node_id,
+                node_title="Resize",
+            )
+    finally:
+        await artifacts.close()
+
+
+@pytest.mark.asyncio
+async def test_only_library_artifacts_are_listed(tmp_path: Path) -> None:
+    store = InMemoryDataStore()
+    seeded = await _seed_run(store)
+    _ = await _seed_uploaded(store)
+    saved_graphs = FakeSavedGraphs()
+    saved_graphs.set_title(seeded.graph_id, "Sales")
+    service, artifacts = _service(store, saved_graphs, tmp_path)
+    try:
+        assert await service.list_items(WORKSPACE_ID) == []
+        await _save_run(service, seeded)
+        items = await service.list_items(WORKSPACE_ID)
+    finally:
+        await artifacts.close()
+
+    assert [item.artifact.artifact_id for item in items] == [seeded.artifact_id]

--- a/tests/unit/core/test_library_provenance.py
+++ b/tests/unit/core/test_library_provenance.py
@@ -1,0 +1,155 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from grafy_core.artifacts import LibraryProvenance
+from pydantic import ValidationError
+
+NOW = datetime(2026, 9, 11, 12, 0, tzinfo=UTC)
+
+
+def _run_provenance() -> LibraryProvenance:
+    return LibraryProvenance.from_run(
+        saved_at=NOW,
+        graph_id=uuid4(),
+        graph_title="Sales",
+        node_id="resize-1",
+        node_title="Resize",
+        graph_revision=4,
+        execution_id=uuid4(),
+    )
+
+
+def test_run_provenance_freezes_the_producing_facts() -> None:
+    provenance = _run_provenance()
+
+    assert provenance.source == "run"
+    assert provenance.graph_title == "Sales"
+    assert provenance.node_title == "Resize"
+    assert provenance.graph_revision == 4
+    assert provenance.execution_id is not None
+    assert provenance.original_filename is None
+
+
+def test_run_provenance_strips_titles() -> None:
+    provenance = LibraryProvenance.from_run(
+        saved_at=NOW,
+        graph_id=uuid4(),
+        graph_title="  Sales  ",
+        node_id="  resize-1  ",
+        node_title="  Resize  ",
+        graph_revision=1,
+        execution_id=uuid4(),
+    )
+
+    assert provenance.graph_id is not None
+    assert provenance.graph_title == "Sales"
+    assert provenance.node_id == "resize-1"
+    assert provenance.node_title == "Resize"
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["graph_id", "graph_title", "node_id", "node_title", "graph_revision", "execution_id"],
+)
+def test_run_provenance_requires_every_producing_fact(missing: str) -> None:
+    fields: dict[str, object] = {
+        "saved_at": NOW,
+        "graph_id": uuid4(),
+        "graph_title": "Sales",
+        "node_id": "resize-1",
+        "node_title": "Resize",
+        "graph_revision": 4,
+        "execution_id": uuid4(),
+    }
+    fields[missing] = None
+
+    with pytest.raises(ValidationError):
+        LibraryProvenance(source="run", **fields)  # pyright: ignore[reportArgumentType]
+
+
+def test_run_provenance_rejects_a_non_positive_revision() -> None:
+    with pytest.raises(ValidationError):
+        LibraryProvenance.from_run(
+            saved_at=NOW,
+            graph_id=uuid4(),
+            graph_title="Sales",
+            node_id="resize-1",
+            node_title="Resize",
+            graph_revision=0,
+            execution_id=uuid4(),
+        )
+
+
+def test_upload_provenance_carries_only_the_filename() -> None:
+    provenance = LibraryProvenance.from_upload(
+        saved_at=NOW,
+        original_filename="  report.csv  ",
+    )
+
+    assert provenance.source == "upload"
+    assert provenance.original_filename == "report.csv"
+    assert provenance.graph_id is None
+    assert provenance.execution_id is None
+
+
+def test_upload_provenance_rejects_run_facts() -> None:
+    with pytest.raises(ValidationError):
+        LibraryProvenance(
+            source="upload",
+            saved_at=NOW,
+            original_filename="report.csv",
+            execution_id=uuid4(),
+        )
+
+
+def test_run_provenance_rejects_an_uploaded_filename() -> None:
+    with pytest.raises(ValidationError):
+        LibraryProvenance(
+            source="run",
+            saved_at=NOW,
+            graph_id=uuid4(),
+            graph_title="Sales",
+            node_id="resize-1",
+            node_title="Resize",
+            graph_revision=4,
+            execution_id=uuid4(),
+            original_filename="report.csv",
+        )
+
+
+def test_provenance_requires_an_aware_save_time() -> None:
+    with pytest.raises(ValidationError):
+        LibraryProvenance.from_upload(
+            saved_at=datetime(2026, 9, 11, 12, 0),
+            original_filename="report.csv",
+        )
+
+
+def test_provenance_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        LibraryProvenance.model_validate(
+            {
+                "source": "upload",
+                "saved_at": NOW,
+                "original_filename": "report.csv",
+                "staleness": "gone",
+            }
+        )
+
+
+def test_provenance_is_frozen() -> None:
+    provenance = _run_provenance()
+
+    with pytest.raises(ValidationError):
+        provenance.graph_title = "Renamed"
+
+
+def test_provenance_round_trips_through_json() -> None:
+    provenance = _run_provenance()
+
+    restored = LibraryProvenance.model_validate(
+        provenance.model_dump(mode="json"),
+    )
+
+    assert restored == provenance

--- a/tests/unit/core/test_saved_graphs.py
+++ b/tests/unit/core/test_saved_graphs.py
@@ -16,7 +16,6 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphAnnotationLayout,
     SavedGraphArtifactTypeBinding,
     SavedGraphDocument,
-    SavedGraphConversion,
     SavedGraphEdge,
     SavedGraphInputPlug,
     SavedGraphNode,

--- a/tests/unit/persistence/test_library_provenance_persistence.py
+++ b/tests/unit/persistence/test_library_provenance_persistence.py
@@ -1,0 +1,122 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from grafy_core.artifacts import ArtifactObject, LibraryProvenance
+from grafy_persistence.database import Database
+from grafy_persistence.unit_of_work import SqlAlchemyUnitOfWork
+
+from tests.unit.persistence.test_execution_history_persistence import (
+    WORKSPACE_ONE,
+    WORKSPACE_TWO,
+)
+from tests.unit.persistence.test_execution_history_persistence import (
+    database as _database_fixture,
+)
+
+database = _database_fixture
+
+
+NOW = datetime(2026, 9, 11, 12, 0, tzinfo=UTC)
+
+
+def _artifact(workspace_id: object, **metadata: object) -> ArtifactObject:
+    return ArtifactObject(
+        workspace_id=workspace_id,  # pyright: ignore[reportArgumentType]
+        artifact_type="text.plain",
+        schema_version=1,
+        content_type="application/json",
+        inline_payload={"text": "hello"},
+        metadata=dict(metadata),
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_provenance_round_trips_on_the_artifact_row(
+    database: Database,
+) -> None:
+    unit_of_work = SqlAlchemyUnitOfWork(database.sessions)
+    artifact = _artifact(WORKSPACE_ONE, download_name="report.json")
+    provenance = LibraryProvenance.from_run(
+        saved_at=NOW,
+        graph_id=uuid4(),
+        graph_title="Sales",
+        node_id="resize-1",
+        node_title="Resize",
+        graph_revision=4,
+        execution_id=uuid4(),
+    )
+    async with unit_of_work as entered:
+        await entered.artifacts.add(artifact)
+        await entered.commit()
+
+    async with unit_of_work as entered:
+        loaded = await entered.artifacts.get(WORKSPACE_ONE, artifact.id)
+        assert loaded is not None
+        assert loaded.library_provenance is None
+        loaded.library_provenance = provenance
+        await entered.commit()
+
+    async with unit_of_work as entered:
+        reloaded = await entered.artifacts.get(WORKSPACE_ONE, artifact.id)
+        listed = await entered.artifacts.list_library(WORKSPACE_ONE)
+
+    assert reloaded is not None
+    assert reloaded.library_provenance == provenance
+    assert [candidate.id for candidate in listed] == [artifact.id]
+
+
+@pytest.mark.asyncio
+async def test_an_uploaded_provenance_round_trips(database: Database) -> None:
+    unit_of_work = SqlAlchemyUnitOfWork(database.sessions)
+    artifact = _artifact(WORKSPACE_ONE, download_name="measurements.csv")
+    provenance = LibraryProvenance.from_upload(
+        saved_at=NOW,
+        original_filename="measurements.csv",
+    )
+    async with unit_of_work as entered:
+        await entered.artifacts.add(artifact)
+        await entered.commit()
+    async with unit_of_work as entered:
+        loaded = await entered.artifacts.get(WORKSPACE_ONE, artifact.id)
+        assert loaded is not None
+        loaded.library_provenance = provenance
+        await entered.commit()
+
+    async with unit_of_work as entered:
+        reloaded = await entered.artifacts.get(WORKSPACE_ONE, artifact.id)
+
+    assert reloaded is not None
+    assert reloaded.library_provenance == provenance
+
+
+@pytest.mark.asyncio
+async def test_library_listing_stays_scoped_to_its_workspace_and_membership(
+    database: Database,
+) -> None:
+    unit_of_work = SqlAlchemyUnitOfWork(database.sessions)
+    library_artifact = _artifact(WORKSPACE_ONE)
+    plain_artifact = _artifact(WORKSPACE_ONE)
+    other_workspace_artifact = _artifact(WORKSPACE_TWO)
+    async with unit_of_work as entered:
+        await entered.artifacts.add(library_artifact)
+        await entered.artifacts.add(plain_artifact)
+        await entered.artifacts.add(other_workspace_artifact)
+        await entered.commit()
+    async with unit_of_work as entered:
+        for artifact, workspace_id in (
+            (library_artifact, WORKSPACE_ONE),
+            (other_workspace_artifact, WORKSPACE_TWO),
+        ):
+            loaded = await entered.artifacts.get(workspace_id, artifact.id)
+            assert loaded is not None
+            loaded.library_provenance = LibraryProvenance.from_upload(
+                saved_at=NOW,
+                original_filename="measurements.csv",
+            )
+        await entered.commit()
+
+    async with unit_of_work as entered:
+        listed = await entered.artifacts.list_library(WORKSPACE_ONE)
+
+    assert [candidate.id for candidate in listed] == [library_artifact.id]

--- a/tests/unit/persistence/test_migrations.py
+++ b/tests/unit/persistence/test_migrations.py
@@ -82,7 +82,7 @@ def test_fresh_postgresql_database_upgrades_to_head(
         _, revision, workspace_count = asyncio.run(
             _postgresql_migration_state(database_url)
         )
-        assert revision == "0027_transient_executions"
+        assert revision == "0028_library_provenance"
         assert workspace_count == 0
         command.check(config)
 


### PR DESCRIPTION
Closes #45

An artifact now carries a birth record, written once when it enters the Library
and never rewritten.

## What it records

- **From a Run**: producing graph id + title, node id + title, graph revision,
  execution id.
- **From an upload**: that it was uploaded, plus the original filename.

Titles are frozen at save time and never resolved live, so the line is exactly
what the save gesture saw. Renaming, re-saving, or deleting the producing graph
afterwards leaves the line as written — there is no staleness chip, no graph
link, and no "source is gone" state.

## Shape

- `LibraryProvenance` — frozen model in `libs/core/.../artifacts.py` with
  `from_run` / `from_upload` factories, source-shaped validation (a run record
  cannot carry a filename and vice versa), tz-aware `saved_at`, and bounded
  titles.
- `artifact_objects.library_provenance` — nullable JSON column, migration
  `0028_library_provenance`. **`non-null` is the in-Library marker.**
- `ArtifactRepositoryPort.list_library` with in-memory and SQL adapters.
- `LibraryService` — `list_items` / `save_from_run` / `save_uploaded`; records
  once and never rewrites an existing record; the run link is present only
  while execution history still holds that run.
- `GET/POST /v1/workspaces/{wid}/library/artifacts[/from-run|/from-upload]`,
  gated on `view_artifacts` for reads and `edit_graph` for writes.
- `LibraryDrawer` — one short provenance line per row
  (`graph · node · revision n · from a run`, or `uploaded · filename`), plus a
  detail panel with the run id, finish time, and a link into execution history.

## Checks from the issue

| Check | Covered by |
| --- | --- |
| Saving a Run artifact writes the four producing facts, shown in row and detail panel | `tests/unit/api/services/test_library_service.py`, `tests/unit/core/test_library_provenance.py`, `apps/web/.../LibraryDrawer.test.tsx` |
| Renaming/deleting the producing graph leaves the line as written | service tests (titles come from the stored snapshot, never re-resolved) |
| Run link opens execution history at that run, absent once the run is gone | service tests + `LibraryDrawer.test.tsx` |
| Upload shows source marker + original filename, no run link | service tests + `LibraryDrawer.test.tsx` |

## Notes for review

Two things are deliberately minimal, per the issue's instruction not to build
the whole Library product:

1. **#25's Library placement columns are not in this codebase yet.** No
   `library_artifacts` table or Library drawer existed. This PR adds only the
   minimum the provenance record needs: a nullable `library_provenance` column
   whose presence means "in the Library". Folders, saved-by, and the row's other
   placement columns are still owed by #25, and the provenance fields are
   designed to sit beside them.
2. **Saving is exposed through the API and covered by tests, but the in-canvas
   "Save to Library" affordance is not wired up yet.** Threading it through
   `ExecutionHistoryDrawer` → `ArtifactPortPreview` (a large component shared
   with the canvas node appendix) was left out rather than shipped half-verified.
   The drawer is also reachable under a **"Saved"** rail button because the
   existing "Library" button already opens the Module workspace library, and
   #25 will settle that surface's naming.

This PR also drops one unused import in `tests/unit/core/test_saved_graphs.py`,
which fails CI's `ruff check` on `main` and would otherwise keep this branch red.

## Verification

- `uv run --all-extras pytest` — 1748 passed; the one failure
  (`test_plugin_egress_docker.py::test_docker_runtime_routes_historical_network_egress_through_live_broker`)
  reproduces on a clean checkout of `main`.
- `uv run ruff check …` — all checks passed.
- `npm --prefix apps/web test` — 621 passed.
- `npm --prefix apps/web run typecheck` / `lint` / `check:api` / `build` — clean.
