### PR TITLE
Persist origin inputs in the saved graph document

### DIFF
--- a/apps/api/src/grafy_api/graph_contracts.py
+++ b/apps/api/src/grafy_api/graph_contracts.py
@@ -2,6 +2,31 @@ from datetime import datetime
 from typing import Annotated, ClassVar, Literal, Self
 from uuid import UUID
 
+from grafy_core.artifacts import ArtifactRef, ArtifactRefSequence
+from grafy_core.conversions import MAX_ARTIFACT_CONVERSION_HOPS
+from grafy_core.domain.collaboration import (
+    CollaborativeGraphHead,
+    CommandReceiptOutcome,
+    GraphCommand,
+    GraphCommandReceipt,
+)
+from grafy_core.domain.identity import WorkspaceKind
+from grafy_core.domain.saved_graphs import (
+    DEFAULT_ANNOTATION_COLOR,
+    GRAPH_LAYOUT_DIMENSION_MAX,
+    AnnotationColor,
+    AnnotationKind,
+    GraphBrowserItem,
+    GraphFolder,
+    GraphIdentifier,
+    GraphOrganization,
+    SavedGraph,
+    SavedGraphDocument,
+    UserGraphState,
+    normalize_saved_graph_edge_conversion,
+    validate_graph_layout_dimensions,
+    validate_graph_node_release_pin,
+)
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -11,36 +36,10 @@ from pydantic import (
     model_validator,
 )
 
-from grafy_core.conversions import MAX_ARTIFACT_CONVERSION_HOPS
-from grafy_core.domain.collaboration import (
-    CollaborativeGraphHead,
-    CommandReceiptOutcome,
-    GraphCommand,
-    GraphCommandReceipt,
-)
-from grafy_core.domain.saved_graphs import (
-    AnnotationColor,
-    AnnotationKind,
-    GraphIdentifier,
-    GRAPH_LAYOUT_DIMENSION_MAX,
-    validate_graph_layout_dimensions,
-    validate_graph_node_release_pin,
-    DEFAULT_ANNOTATION_COLOR,
-    GraphBrowserItem,
-    GraphFolder,
-    GraphOrganization,
-    SavedGraph,
-    SavedGraphDocument,
-    UserGraphState,
-    normalize_saved_graph_edge_conversion,
-)
-from grafy_core.domain.identity import WorkspaceKind
-
 from grafy_api.v1.models import (
     ArtifactTypeBindingModel,
     PluginReleasePinModel,
 )
-
 
 Identifier = GraphIdentifier
 
@@ -130,6 +129,18 @@ class SavedGraphEdgeModel(SavedGraphApiModel):
 
     normalize_singular_conversion = model_validator(mode="before")(
         normalize_saved_graph_edge_conversion
+    )
+
+
+class SavedGraphOriginModel(SavedGraphApiModel):
+    id: Identifier
+    to_node: Identifier
+    to_port: Identifier
+    to_plug: Identifier | None = None
+    value: ArtifactRef | ArtifactRefSequence
+    conversion_path: list[SavedGraphConversionModel] = Field(
+        default_factory=list,
+        max_length=MAX_ARTIFACT_CONVERSION_HOPS,
     )
 
 
@@ -444,6 +455,7 @@ class CollaborativeHeadResponse(SavedGraphApiModel):
     updated_at: datetime
     nodes: list[SavedGraphNodeModel]
     edges: list[SavedGraphEdgeModel]
+    origins: list[SavedGraphOriginModel] = Field(default_factory=list)
     presentation: GraphPresentationDocumentModel = Field(
         default_factory=GraphPresentationDocumentModel,
     )

--- a/apps/web/openapi/grafy.json
+++ b/apps/web/openapi/grafy.json
@@ -39,6 +39,25 @@
         "title": "AddNodeCommand",
         "type": "object"
       },
+      "AddOriginCommand": {
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "const": "add_origin",
+            "default": "add_origin",
+            "title": "Kind",
+            "type": "string"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/SavedGraphOrigin"
+          }
+        },
+        "required": [
+          "origin"
+        ],
+        "title": "AddOriginCommand",
+        "type": "object"
+      },
       "ArtifactBundleContractResponse": {
         "properties": {
           "format": {
@@ -660,6 +679,13 @@
               "$ref": "#/components/schemas/SavedGraphNodeModel"
             },
             "title": "Nodes",
+            "type": "array"
+          },
+          "origins": {
+            "items": {
+              "$ref": "#/components/schemas/SavedGraphOriginModel"
+            },
+            "title": "Origins",
             "type": "array"
           },
           "presentation": {
@@ -4463,6 +4489,30 @@
         "title": "RemoveNodesCommand",
         "type": "object"
       },
+      "RemoveOriginsCommand": {
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "const": "remove_origins",
+            "default": "remove_origins",
+            "title": "Kind",
+            "type": "string"
+          },
+          "origin_ids": {
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Origin Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "origin_ids"
+        ],
+        "title": "RemoveOriginsCommand",
+        "type": "object"
+      },
       "RenameGraphCommand": {
         "additionalProperties": false,
         "properties": {
@@ -5168,12 +5218,20 @@
             "title": "Nodes",
             "type": "array"
           },
+          "origins": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SavedGraphOrigin"
+            },
+            "title": "Origins",
+            "type": "array"
+          },
           "presentation": {
             "$ref": "#/components/schemas/GraphPresentationDocument"
           },
           "schema_version": {
-            "const": 6,
-            "default": 6,
+            "const": 7,
+            "default": 7,
             "title": "Schema Version",
             "type": "integer"
           }
@@ -5716,6 +5774,134 @@
         "title": "SavedGraphNodeModel",
         "type": "object"
       },
+      "SavedGraphOrigin": {
+        "additionalProperties": false,
+        "description": "Exact artifact value held on one node input with no incoming edge.",
+        "properties": {
+          "conversion_path": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SavedGraphConversion"
+            },
+            "maxItems": 8,
+            "title": "Conversion Path",
+            "type": "array"
+          },
+          "id": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Id",
+            "type": "string"
+          },
+          "to_node": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "To Node",
+            "type": "string"
+          },
+          "to_plug": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "To Plug"
+          },
+          "to_port": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "To Port",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtifactRef"
+              },
+              {
+                "$ref": "#/components/schemas/ArtifactRefSequence"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "id",
+          "to_node",
+          "to_port",
+          "value"
+        ],
+        "title": "SavedGraphOrigin",
+        "type": "object"
+      },
+      "SavedGraphOriginModel": {
+        "additionalProperties": false,
+        "properties": {
+          "conversion_path": {
+            "items": {
+              "$ref": "#/components/schemas/SavedGraphConversionModel"
+            },
+            "maxItems": 8,
+            "title": "Conversion Path",
+            "type": "array"
+          },
+          "id": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Id",
+            "type": "string"
+          },
+          "to_node": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "To Node",
+            "type": "string"
+          },
+          "to_plug": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "To Plug"
+          },
+          "to_port": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "To Port",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtifactRef"
+              },
+              {
+                "$ref": "#/components/schemas/ArtifactRefSequence"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "id",
+          "to_node",
+          "to_port",
+          "value"
+        ],
+        "title": "SavedGraphOriginModel",
+        "type": "object"
+      },
       "SavedGraphPluginReleasePin": {
         "additionalProperties": false,
         "description": "Exact scoped Plugin release identity pinned on one graph node.\n\nThe pin is independent from the operator identity: publishing revision\nN+1 never moves a node pinned to revision N. Workspace membership for a\nWorkspace release comes from the owning graph.",
@@ -6030,6 +6216,7 @@
               "mapping": {
                 "add_edge": "#/components/schemas/AddEdgeCommand",
                 "add_node": "#/components/schemas/AddNodeCommand",
+                "add_origin": "#/components/schemas/AddOriginCommand",
                 "clear_node_artifact_type_binding": "#/components/schemas/ClearNodeArtifactTypeBindingCommand",
                 "duplicate_node": "#/components/schemas/DuplicateNodeCommand",
                 "move_annotations": "#/components/schemas/MoveAnnotationsCommand",
@@ -6037,6 +6224,7 @@
                 "move_nodes": "#/components/schemas/MoveNodesCommand",
                 "remove_edges": "#/components/schemas/RemoveEdgesCommand",
                 "remove_nodes": "#/components/schemas/RemoveNodesCommand",
+                "remove_origins": "#/components/schemas/RemoveOriginsCommand",
                 "rename_graph": "#/components/schemas/RenameGraphCommand",
                 "replace_document": "#/components/schemas/ReplaceDocumentCommand",
                 "replace_presentation": "#/components/schemas/ReplacePresentationCommand",
@@ -6046,7 +6234,8 @@
                 "update_node_configuration": "#/components/schemas/UpdateNodeConfigurationCommand",
                 "update_node_configuration_and_input_plugs": "#/components/schemas/UpdateNodeConfigurationAndInputPlugsCommand",
                 "update_node_layout": "#/components/schemas/UpdateNodeLayoutCommand",
-                "update_node_plugin_release": "#/components/schemas/UpdateNodePluginReleaseCommand"
+                "update_node_plugin_release": "#/components/schemas/UpdateNodePluginReleaseCommand",
+                "update_origin": "#/components/schemas/UpdateOriginCommand"
               },
               "propertyName": "kind"
             },
@@ -6095,6 +6284,15 @@
               },
               {
                 "$ref": "#/components/schemas/RemoveEdgesCommand"
+              },
+              {
+                "$ref": "#/components/schemas/AddOriginCommand"
+              },
+              {
+                "$ref": "#/components/schemas/UpdateOriginCommand"
+              },
+              {
+                "$ref": "#/components/schemas/RemoveOriginsCommand"
               },
               {
                 "$ref": "#/components/schemas/ReplaceDocumentCommand"
@@ -6847,6 +7045,29 @@
           "expected_plugin_release_pin"
         ],
         "title": "UpdateNodePluginReleaseCommand",
+        "type": "object"
+      },
+      "UpdateOriginCommand": {
+        "additionalProperties": false,
+        "properties": {
+          "expected_origin": {
+            "$ref": "#/components/schemas/SavedGraphOrigin"
+          },
+          "kind": {
+            "const": "update_origin",
+            "default": "update_origin",
+            "title": "Kind",
+            "type": "string"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/SavedGraphOrigin"
+          }
+        },
+        "required": [
+          "origin",
+          "expected_origin"
+        ],
+        "title": "UpdateOriginCommand",
         "type": "object"
       },
       "UpdateSavedGraphRequest": {

--- a/apps/web/src/features/workbench/canvas/graph-document-adapter.test.ts
+++ b/apps/web/src/features/workbench/canvas/graph-document-adapter.test.ts
@@ -56,6 +56,7 @@ function state(): WorkbenchAuthoringState {
       name: "Draft",
       nodes: [source, target],
       edges: [edge],
+      origins: [],
     })),
     nodeOverlays: {
       source: {
@@ -316,6 +317,7 @@ describe("Workbench authored document adapter", () => {
           to_node: "descendant",
         },
       ],
+      origins: [],
     };
     const initial: WorkbenchAuthoringState = {
       document: authoredGraphDocument(createSavedGraphRequest(withDescendant)),
@@ -369,6 +371,7 @@ describe("Workbench authored document adapter", () => {
           enabled: false,
         },
       ],
+      origins: [],
     };
     const initial: WorkbenchAuthoringState = {
       document: authoredGraphDocument(createSavedGraphRequest(withDisabledEdge)),

--- a/apps/web/src/features/workbench/canvas/saved-graph.test.ts
+++ b/apps/web/src/features/workbench/canvas/saved-graph.test.ts
@@ -118,7 +118,8 @@ function graphWithEdge(
     created_at: "2026-07-15T12:00:00Z",
     updated_at: "2026-07-15T12:00:00Z",
     document: {
-      schema_version: 6,
+      schema_version: 7,
+      origins: [],
       nodes: [
         {
           id: "source-node",
@@ -663,7 +664,8 @@ function graphWithCollectPlugs(): SavedGraph {
     created_at: "2026-07-15T12:00:00Z",
     updated_at: "2026-07-15T12:00:00Z",
     document: {
-      schema_version: 6,
+      schema_version: 7,
+      origins: [],
       nodes: [
         {
           id: "source-node",
@@ -815,7 +817,8 @@ function graphWithGenericCollectBinding(): SavedGraph {
     created_at: "2026-07-15T12:00:00Z",
     updated_at: "2026-07-15T12:00:00Z",
     document: {
-      schema_version: 6,
+      schema_version: 7,
+      origins: [],
       nodes: [
         {
           id: "source-node",
@@ -1027,7 +1030,8 @@ describe("saved graph module nodes", () => {
       created_at: "2026-07-16T12:00:00Z",
       updated_at: "2026-07-16T12:00:00Z",
       document: {
-        schema_version: 6,
+        schema_version: 7,
+        origins: [],
         nodes: [
           {
             id: "images",

--- a/apps/web/src/features/workbench/model/graph-document.test.ts
+++ b/apps/web/src/features/workbench/model/graph-document.test.ts
@@ -41,6 +41,7 @@ function document(): AuthoredGraphDocument {
     name: "Draft",
     nodes: [node("source"), node("target")],
     edges: [edge],
+    origins: [],
   }));
 }
 
@@ -52,9 +53,10 @@ describe("authored graph document", () => {
     expect(request).toEqual({
       name: value.name,
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: value.nodes,
         edges: value.edges,
+        origins: [],
         presentation: {
           viewers: [],
           links: [],
@@ -75,7 +77,7 @@ describe("authored graph document", () => {
     const input: CreateSavedGraphRequest = {
       name: "Operator-agnostic graph",
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: [
           {
             id: "legacy-node",
@@ -124,6 +126,7 @@ describe("authored graph document", () => {
             route_offset: { x: 18, y: -6 },
           },
         ],
+        origins: [],
         presentation: {
           viewers: [],
           links: [],
@@ -138,7 +141,7 @@ describe("authored graph document", () => {
     expect(createSavedGraphRequest(canonical)).toEqual({
       name: "Operator-agnostic graph",
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: [
         {
           id: "legacy-node",
@@ -188,6 +191,7 @@ describe("authored graph document", () => {
           route_offset: { x: 18, y: -6 },
         },
         ],
+        origins: [],
         presentation: {
           viewers: [],
           links: [],
@@ -231,13 +235,14 @@ describe("authored graph document", () => {
     const input: CreateSavedGraphRequest = {
       name: "Adversarial graph",
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: [
           runtimeNode as unknown as SavedGraphDocument["nodes"][number],
         ],
         edges: [
           runtimeEdge as unknown as SavedGraphDocument["edges"][number],
         ],
+        origins: [],
         presentation: {
           viewers: [],
           links: [],
@@ -549,6 +554,112 @@ describe("authored graph document", () => {
     });
   });
 
+  it("adds, updates, and removes an origin through typed semantic commands", () => {
+    const added = applyGraphCommand(document(), {
+      kind: "add_origin",
+      origin: {
+        id: "origin-1",
+        to_node: "target",
+        to_port: "input",
+        to_plug: null,
+        value: {
+          artifact_id: "00000000-0000-4000-8000-000000000001",
+          artifact_type: "scalar.text",
+          schema_version: 1,
+        },
+        conversion_path: [],
+      },
+    });
+
+    expect(added.origins).toEqual([
+      {
+        id: "origin-1",
+        to_node: "target",
+        to_port: "input",
+        to_plug: null,
+        value: {
+          artifact_id: "00000000-0000-4000-8000-000000000001",
+          artifact_type: "scalar.text",
+          schema_version: 1,
+        },
+        conversion_path: [],
+      },
+    ]);
+
+    const updated = applyGraphCommand(added, {
+      kind: "update_origin",
+      origin_id: "origin-1",
+      update: { conversion_path: [{ id: "text.normalize", version: 2 }] },
+    });
+
+    expect(updated.origins[0]?.conversion_path).toEqual([
+      { id: "text.normalize", version: 2 },
+    ]);
+
+    const removed = applyGraphCommand(updated, {
+      kind: "remove_origins",
+      origin_ids: ["origin-1"],
+    });
+
+    expect(removed.origins).toEqual([]);
+  });
+
+  it("prunes origins that target a removed node", () => {
+    const withOrigin = applyGraphCommand(document(), {
+      kind: "add_origin",
+      origin: {
+        id: "origin-1",
+        to_node: "target",
+        to_port: "input",
+        to_plug: null,
+        value: {
+          artifact_id: "00000000-0000-4000-8000-000000000001",
+          artifact_type: "scalar.text",
+          schema_version: 1,
+        },
+        conversion_path: [],
+      },
+    });
+
+    const result = applyGraphCommand(withOrigin, {
+      kind: "remove_nodes",
+      node_ids: ["target"],
+    });
+
+    expect(result.origins).toEqual([]);
+  });
+
+  it("rejects origin commands that target a missing or duplicate origin", () => {
+    expect(() =>
+      applyGraphCommand(document(), {
+        kind: "update_origin",
+        origin_id: "missing-origin",
+        update: { to_port: "other" },
+      }),
+    ).toThrow("missing origin missing-origin");
+
+    const origin = {
+      id: "origin-1",
+      to_node: "target",
+      to_port: "input",
+      to_plug: null,
+      value: {
+        artifact_id: "00000000-0000-4000-8000-000000000001",
+        artifact_type: "scalar.text",
+        schema_version: 1,
+      },
+      conversion_path: [],
+    };
+    const withOrigin = applyGraphCommand(document(), {
+      kind: "add_origin",
+      origin,
+    });
+
+    expect(() =>
+      applyGraphCommand(withOrigin, { kind: "add_origin", origin }),
+    ).toThrow("duplicate origin origin-1");
+  });
+
   it("moves only the selected exact Plugin release pin", () => {
     const original = authoredGraphDocument(createSavedGraphRequest({
       name: "Pinned Plugins",
@@ -571,6 +682,7 @@ describe("authored graph document", () => {
         },
       ],
       edges: [edge],
+      origins: [],
     }));
 
     const upgraded = applyGraphCommand(original, {

--- a/apps/web/src/features/workbench/model/graph-document.ts
+++ b/apps/web/src/features/workbench/model/graph-document.ts
@@ -1,3 +1,4 @@
+import type { SavedGraphOrigin } from "@/lib/api";
 import type {
   CreateSavedGraphRequest,
   SavedGraphDocument,
@@ -16,10 +17,12 @@ export interface AuthoredGraphDocument {
   readonly name: string;
   readonly nodes: readonly SavedGraphNode[];
   readonly edges: readonly SavedGraphEdge[];
+  readonly origins: readonly SavedGraphOrigin[];
 }
 
 export type AuthoredGraphNode = SavedGraphNode;
 export type AuthoredGraphEdge = SavedGraphEdge;
+export type AuthoredGraphOrigin = SavedGraphOrigin;
 
 type SavedGraphEdgeUpdate = Partial<
   Pick<
@@ -32,6 +35,13 @@ type SavedGraphEdgeUpdate = Partial<
     | "to_plug"
     | "from_port"
     | "to_port"
+  >
+>;
+
+type SavedGraphOriginUpdate = Partial<
+  Pick<
+    AuthoredGraphOrigin,
+    "to_node" | "to_port" | "to_plug" | "value" | "conversion_path"
   >
 >;
 
@@ -126,6 +136,19 @@ export type GraphCommand =
       readonly edge_ids: readonly string[];
     }
   | {
+      readonly kind: "add_origin";
+      readonly origin: AuthoredGraphOrigin;
+    }
+  | {
+      readonly kind: "update_origin";
+      readonly origin_id: string;
+      readonly update: SavedGraphOriginUpdate;
+    }
+  | {
+      readonly kind: "remove_origins";
+      readonly origin_ids: readonly string[];
+    }
+  | {
       readonly kind: "replace_document";
       readonly document: AuthoredGraphDocument;
     };
@@ -137,6 +160,7 @@ export function authoredGraphDocument(
     name: value.name,
     nodes: value.document.nodes.map(projectSavedGraphNode),
     edges: value.document.edges.map(projectSavedGraphEdge),
+    origins: (value.document.origins ?? []).map(projectSavedGraphOrigin),
   };
 }
 
@@ -147,9 +171,10 @@ export function createSavedGraphRequest(
   return {
     name: document.name.trim(),
     document: {
-      schema_version: 6,
+      schema_version: 7,
       nodes: document.nodes.map(projectSavedGraphNode),
       edges: document.edges.map(projectSavedGraphEdge),
+      origins: (document.origins ?? []).map(projectSavedGraphOrigin),
       presentation: presentation ?? {
         viewers: [],
         links: [],
@@ -291,6 +316,51 @@ function projectSavedGraphEdgeUpdate(
   return projected;
 }
 
+export function projectSavedGraphOrigin(
+  origin: SavedGraphOrigin,
+): SavedGraphOrigin {
+  return {
+    conversion_path: (origin.conversion_path ?? []).map((conversion) => ({
+      id: conversion.id,
+      version: conversion.version,
+    })),
+    id: origin.id,
+    to_node: origin.to_node,
+    to_plug: origin.to_plug ?? null,
+    to_port: origin.to_port,
+    value: structuredClone(origin.value),
+  };
+}
+
+function projectSavedGraphOriginUpdate(
+  update: SavedGraphOriginUpdate,
+): SavedGraphOriginUpdate {
+  const projected = {} as {
+    -readonly [Key in keyof SavedGraphOriginUpdate]: SavedGraphOriginUpdate[Key];
+  };
+  if (Object.prototype.hasOwnProperty.call(update, "to_node")) {
+    projected.to_node = update.to_node;
+  }
+  if (Object.prototype.hasOwnProperty.call(update, "to_port")) {
+    projected.to_port = update.to_port;
+  }
+  if (Object.prototype.hasOwnProperty.call(update, "to_plug")) {
+    projected.to_plug = update.to_plug ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(update, "value")) {
+    projected.value =
+      update.value === null || update.value === undefined
+        ? update.value
+        : structuredClone(update.value);
+  }
+  if (Object.prototype.hasOwnProperty.call(update, "conversion_path")) {
+    projected.conversion_path = (update.conversion_path ?? []).map(
+      ({ id, version }) => ({ id, version }),
+    );
+  }
+  return projected;
+}
+
 function executionDescendants(
   document: AuthoredGraphDocument,
   roots: readonly string[],
@@ -352,13 +422,32 @@ export function executionInvalidatedNodeIds(
           .filter((edge) => command.edge_ids.includes(edge.id))
           .map((edge) => edge.to_node),
       );
-    case "remove_nodes":
+    case "add_origin":
+      return executionDescendants(document, [command.origin.to_node]);
+    case "update_origin": {
+      const origin = document.origins.find(
+        (candidate) => candidate.id === command.origin_id,
+      );
+      return origin
+        ? executionDescendants(document, [origin.to_node])
+        : new Set();
+    }
+    case "remove_origins":
       return executionDescendants(
         document,
-        document.edges
+        document.origins
+          .filter((origin) => command.origin_ids.includes(origin.id))
+          .map((origin) => origin.to_node),
+      );
+    case "remove_nodes":
+      return executionDescendants(document, [
+        ...document.edges
           .filter((edge) => command.node_ids.includes(edge.from_node))
           .map((edge) => edge.to_node),
-      );
+        ...document.origins
+          .filter((origin) => command.node_ids.includes(origin.to_node))
+          .map((origin) => origin.to_node),
+      ]);
     case "rename_graph":
     case "add_node":
     case "move_nodes":
@@ -385,6 +474,18 @@ function edgeOrThrow(
   const edge = document.edges.find((candidate) => candidate.id === edgeId);
   if (!edge) throw new Error(`Graph command targets missing edge ${edgeId}`);
   return edge;
+}
+
+function originOrThrow(
+  document: AuthoredGraphDocument,
+  originId: string,
+): AuthoredGraphOrigin {
+  const origin = document.origins.find(
+    (candidate) => candidate.id === originId,
+  );
+  if (!origin)
+    throw new Error(`Graph command targets missing origin ${originId}`);
+  return origin;
 }
 
 function updateNode(
@@ -429,6 +530,9 @@ export function applyGraphCommandNormalized(
         nodes: document.nodes.filter((node) => !removed.has(node.id)),
         edges: document.edges.filter(
           (edge) => !removed.has(edge.from_node) && !removed.has(edge.to_node),
+        ),
+        origins: document.origins.filter(
+          (origin) => !removed.has(origin.to_node),
         ),
       };
     }
@@ -492,6 +596,11 @@ export function applyGraphCommandNormalized(
             edge.to_node !== command.node_id ||
             edge.to_plug !== command.plug_id,
         ),
+        origins: next.origins.filter(
+          (origin) =>
+            origin.to_node !== command.node_id ||
+            origin.to_plug !== command.plug_id,
+        ),
       };
     }
     case "reorder_input_plug":
@@ -532,6 +641,13 @@ export function applyGraphCommandNormalized(
             edge.to_plug === null ||
             edge.to_plug === undefined ||
             retainedPlugIds.has(edge.to_plug),
+        ),
+        origins: next.origins.filter(
+          (origin) =>
+            origin.to_node !== command.node_id ||
+            origin.to_plug === null ||
+            origin.to_plug === undefined ||
+            retainedPlugIds.has(origin.to_plug),
         ),
       };
     }
@@ -582,6 +698,41 @@ export function applyGraphCommandNormalized(
       return {
         ...document,
         edges: document.edges.filter((edge) => !removed.has(edge.id)),
+      };
+    }
+    case "add_origin":
+      if (
+        document.origins.some(
+          (origin) => origin.id === command.origin.id,
+        )
+      ) {
+        throw new Error(
+          `Graph command adds duplicate origin ${command.origin.id}`,
+        );
+      }
+      return {
+        ...document,
+        origins: [
+          ...document.origins,
+          projectSavedGraphOrigin(command.origin),
+        ],
+      };
+    case "update_origin": {
+      originOrThrow(document, command.origin_id);
+      return {
+        ...document,
+        origins: document.origins.map((origin) =>
+          origin.id === command.origin_id
+            ? { ...origin, ...projectSavedGraphOriginUpdate(command.update) }
+            : origin,
+        ),
+      };
+    }
+    case "remove_origins": {
+      const removed = new Set(command.origin_ids);
+      return {
+        ...document,
+        origins: document.origins.filter((origin) => !removed.has(origin.id)),
       };
     }
     case "replace_document":

--- a/apps/web/src/features/workbench/room/graph-head-transport.test.ts
+++ b/apps/web/src/features/workbench/room/graph-head-transport.test.ts
@@ -19,7 +19,7 @@ const canonical: CollaborativeHead = {
   checkpoint_revision: 2,
   updated_at: "2026-09-09T10:00:00Z",
   document: {
-    schema_version: 6,
+    schema_version: 7,
     nodes: [{
       id: "source", kind: "plugin", operator_id: "table.read", operator_version: 1,
       plugin_release_pin: { scope: "system", slug: "tables", revision: 7 },
@@ -34,6 +34,11 @@ const canonical: CollaborativeHead = {
       to_node: "target", to_port: "rows", to_plug: "rows-1",
       enabled: true, collection_mode: "map", conversion_path: [],
       projection: { path: ["records"] }, route_offset: { x: 4, y: 5 },
+    }],
+    origins: [{
+      id: "origin-1", to_node: "target", to_port: "rows", to_plug: "rows-1",
+      value: { artifact_id: "00000000-0000-4000-8000-000000000002", artifact_type: "rows", schema_version: 1 },
+      conversion_path: [],
     }],
     presentation: {
       viewers: [{ id: "viewer-1", position: { x: 80, y: 90 }, mode: "table" }],
@@ -51,6 +56,7 @@ const legacy: LegacyCollaborativeHead = {
     ...node, plugin_release: plugin_release_pin,
   })),
   edges: canonical.document.edges,
+  origins: canonical.document.origins,
   presentation: canonical.document.presentation,
 };
 
@@ -121,12 +127,14 @@ describe("canonical collaborative head flow", () => {
         ...legacy, presentation: undefined,
         nodes: legacy.nodes.map((node) => ({ ...node, artifact_type_bindings: undefined, input_plugs: undefined })),
         edges: legacy.edges.map((edge) => ({ ...edge, conversion_path: undefined })),
+        origins: (legacy.origins ?? []).map((origin) => ({ ...origin, conversion_path: undefined })),
       },
     });
     if (room?.type !== "room.rehydrate") throw new Error("Expected a parsed v1 reset");
     expect(room.head.document.nodes[0]?.input_plugs).toEqual([]);
     expect(room.head.document.nodes[0]?.artifact_type_bindings).toEqual([]);
     expect(room.head.document.edges[0]?.conversion_path).toEqual([]);
+    expect(room.head.document.origins[0]?.conversion_path).toEqual([]);
     expect(room.head.document.presentation).toEqual({ viewers: [], links: [], bindings: [], annotations: [] });
   });
 

--- a/apps/web/src/features/workbench/room/graph-room-session.test.ts
+++ b/apps/web/src/features/workbench/room/graph-room-session.test.ts
@@ -824,9 +824,10 @@ describe("GraphRoomSession", () => {
       kind: "replace_document" as const,
       name: "Checkpointed in E1",
       document: {
-        schema_version: 6 as const,
+        schema_version: 7 as const,
         nodes: [],
         edges: [],
+        origins: [],
         presentation: {
           viewers: [],
           links: [],

--- a/apps/web/src/features/workbench/room/room-command-bridge.test.ts
+++ b/apps/web/src/features/workbench/room/room-command-bridge.test.ts
@@ -24,6 +24,7 @@ const document: AuthoredGraphDocument = {
     },
   ],
   edges: [],
+  origins: [],
 };
 
 const head: CollaborativeHead = {
@@ -35,9 +36,10 @@ const head: CollaborativeHead = {
   name: "Demo",
   updated_at: "2026-08-07T12:00:00Z",
   document: {
-    schema_version: 6,
+    schema_version: 7,
     nodes: document.nodes,
-    edges: []
+    edges: [],
+    origins: []
   }
 };
 
@@ -162,7 +164,7 @@ describe("room-command-bridge", () => {
     const room = toRoomGraphCommand(
       {
         kind: "replace_document",
-        document: { name: "Replacement", nodes: [scopedNode], edges: [] },
+        document: { name: "Replacement", nodes: [scopedNode], edges: [], origins: [] },
       },
       document,
     );
@@ -219,9 +221,10 @@ describe("room-command-bridge", () => {
     const room = toRoomReplaceDocumentCommand({
       name: "Replacement",
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: [scopedNode],
         edges: [],
+        origins: [],
         presentation: {
           viewers: [],
           links: [],
@@ -235,7 +238,7 @@ describe("room-command-bridge", () => {
       kind: "replace_document",
       name: "Replacement",
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: [
           {
             artifact_type_bindings: [
@@ -260,6 +263,7 @@ describe("room-command-bridge", () => {
           },
         ],
         edges: [],
+        origins: [],
         presentation: {
           viewers: [],
           links: [],
@@ -281,7 +285,7 @@ describe("room-command-bridge", () => {
           revision: 12,
         },
       },
-      { name: "Demo", nodes: [scopedNode], edges: [] },
+      { name: "Demo", nodes: [scopedNode], edges: [], origins: [] },
     );
 
     expect(room).toEqual({
@@ -341,7 +345,7 @@ describe("room-command-bridge", () => {
           revision: 12,
         },
       },
-      { name: "Demo", nodes: [scopedNode], edges: [] },
+      { name: "Demo", nodes: [scopedNode], edges: [], origins: [] },
     );
     if (!room) throw new Error("Expected Plugin upgrade command");
 
@@ -383,6 +387,84 @@ describe("room-command-bridge", () => {
     });
   });
 
+  it("maps origin commands through the room protocol in both directions", () => {
+    const origin = {
+      id: "origin-1",
+      to_node: "a",
+      to_port: "input",
+      to_plug: null,
+      value: {
+        artifact_id: "00000000-0000-4000-8000-000000000001",
+        artifact_type: "scalar.text",
+        schema_version: 1,
+      },
+      conversion_path: [],
+    };
+    const withOrigin = { ...document, origins: [origin] };
+
+    expect(toRoomGraphCommand({ kind: "add_origin", origin }, document)).toEqual({
+      kind: "add_origin",
+      origin,
+    });
+    expect(toLocalGraphCommand({ kind: "add_origin", origin })).toEqual({
+      kind: "add_origin",
+      origin,
+    });
+    expect(
+      toRoomGraphCommand(
+        {
+          kind: "update_origin",
+          origin_id: "origin-1",
+          update: { to_plug: "plug-1" },
+        },
+        withOrigin,
+      ),
+    ).toEqual({
+      kind: "update_origin",
+      expected_origin: origin,
+      origin: { ...origin, to_plug: "plug-1" },
+    });
+    expect(
+      toLocalGraphCommand({
+        kind: "update_origin",
+        expected_origin: origin,
+        origin: { ...origin, to_port: "other" },
+      }),
+    ).toEqual({
+      kind: "update_origin",
+      origin_id: "origin-1",
+      update: {
+        to_node: "a",
+        to_port: "other",
+        to_plug: null,
+        value: origin.value,
+        conversion_path: [],
+      },
+    });
+    expect(
+      toRoomGraphCommand(
+        {
+          kind: "update_origin",
+          origin_id: "missing-origin",
+          update: { to_port: "other" },
+        },
+        document,
+      ),
+    ).toBeNull();
+    expect(
+      toRoomGraphCommand(
+        { kind: "remove_origins", origin_ids: ["origin-1"] },
+        withOrigin,
+      ),
+    ).toEqual({ kind: "remove_origins", origin_ids: ["origin-1"] });
+    expect(
+      toLocalGraphCommand({
+        kind: "remove_origins",
+        origin_ids: ["origin-1"],
+      }),
+    ).toEqual({ kind: "remove_origins", origin_ids: ["origin-1"] });
+  });
+
   it("applies accepted move_nodes onto the collaborative head", () => {
     const next = applyRoomCommandToHead(
       head,
@@ -403,9 +485,10 @@ describe("room-command-bridge", () => {
         kind: "replace_document",
         name: "Replaced",
         document: {
-          schema_version: 6,
+          schema_version: 7,
           nodes: [],
           edges: [],
+          origins: [],
         },
       },
       5,

--- a/apps/web/src/features/workbench/room/room-command-bridge.ts
+++ b/apps/web/src/features/workbench/room/room-command-bridge.ts
@@ -11,6 +11,7 @@ import {
   createSavedGraphRequest,
   projectSavedGraphNode,
   projectSavedGraphEdge,
+  projectSavedGraphOrigin,
   type AuthoredGraphDocument,
   type GraphCommand,
 } from "../model/graph-document";
@@ -31,9 +32,10 @@ export function toRoomReplaceDocumentCommand(
     kind: "replace_document",
     name: document.name,
     document: {
-      schema_version: 6,
+      schema_version: 7,
       nodes: document.nodes.map(projectSavedGraphNode),
       edges: document.edges.map(projectSavedGraphEdge),
+      origins: document.origins.map(projectSavedGraphOrigin),
       presentation: {
         annotations: [...(presentation.annotations ?? [])],
         bindings: [...(presentation.bindings ?? [])],
@@ -74,6 +76,16 @@ export function toRoomGraphCommand(
       return asRoom({
         kind: "remove_edges",
         edge_ids: [...command.edge_ids],
+      });
+    case "add_origin":
+      return {
+        kind: "add_origin",
+        origin: projectSavedGraphOrigin(command.origin),
+      };
+    case "remove_origins":
+      return asRoom({
+        kind: "remove_origins",
+        origin_ids: [...command.origin_ids],
       });
     case "rename_graph":
       return asRoom({
@@ -183,6 +195,17 @@ export function toRoomGraphCommand(
         kind: "update_edge",
         expected_edge: projectSavedGraphEdge(edge),
         edge: projectSavedGraphEdge({ ...edge, ...command.update }),
+      };
+    }
+    case "update_origin": {
+      const origin = document.origins.find(
+        (candidate) => candidate.id === command.origin_id,
+      );
+      if (!origin) return null;
+      return {
+        kind: "update_origin",
+        expected_origin: projectSavedGraphOrigin(origin),
+        origin: projectSavedGraphOrigin({ ...origin, ...command.update }),
       };
     }
     case "replace_document": {
@@ -304,6 +327,22 @@ export function toLocalGraphCommand(
           route_offset: command.edge.route_offset,
         },
       };
+    case "add_origin":
+      return { kind: "add_origin", origin: command.origin };
+    case "update_origin":
+      return {
+        kind: "update_origin",
+        origin_id: command.origin.id,
+        update: {
+          to_node: command.origin.to_node,
+          to_port: command.origin.to_port,
+          to_plug: command.origin.to_plug,
+          value: command.origin.value,
+          conversion_path: command.origin.conversion_path,
+        },
+      };
+    case "remove_origins":
+      return { kind: "remove_origins", origin_ids: command.origin_ids };
     case "replace_document":
       return {
         kind: "replace_document",
@@ -346,9 +385,10 @@ export function applyRoomCommandToHead(
       ...head,
       name: command.name,
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: command.document.nodes.map(projectSavedGraphNode),
         edges: command.document.edges,
+        origins: command.document.origins,
         presentation: command.document.presentation ?? emptyGraphPresentation(),
       },
       collaboration_sequence: sequence,

--- a/apps/web/src/features/workbench/ui/Workbench.tsx
+++ b/apps/web/src/features/workbench/ui/Workbench.tsx
@@ -388,6 +388,7 @@ function WorkbenchBody({
         name: "Untitled workflow",
         nodes: [],
         edges: [],
+        origins: [],
       },
       nodeOverlays: {},
       error: null,
@@ -1150,6 +1151,8 @@ function WorkbenchBody({
 
   const openGraphInNewTab = React.useCallback(
     (graphId: string) => {
+      // Internal route: workbenchGraphPath() returns a same-origin path from encoded params.
+      // pi-lens-ignore: no-open-redirect
       window.open(
         workbenchGraphPath(workspaceSlug, graphId),
         "_blank",

--- a/apps/web/src/features/workbench/ui/useRunExecution.test.ts
+++ b/apps/web/src/features/workbench/ui/useRunExecution.test.ts
@@ -54,7 +54,7 @@ const executionId = "00000000-0000-4000-8000-000000000001";
 const executionDraft: CreateSavedGraphRequest = {
   name: "Execution snapshot",
   document: {
-    schema_version: 6,
+    schema_version: 7,
     nodes: [{
       id: "node-1",
       kind: "builtin",
@@ -66,6 +66,7 @@ const executionDraft: CreateSavedGraphRequest = {
       position: { x: 0, y: 0 },
     }],
     edges: [],
+    origins: [],
     presentation: {
       viewers: [],
       links: [],

--- a/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.test.ts
+++ b/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.test.ts
@@ -71,9 +71,10 @@ function savedGraph(
     created_at: "2026-07-17T12:00:00Z",
     updated_at: "2026-07-17T12:00:00Z",
     document: {
-      schema_version: 6,
+      schema_version: 7,
       nodes: [],
       edges: [],
+      origins: [],
       presentation: {
         viewers: [],
         links: [],
@@ -117,18 +118,21 @@ function lifecycleOptions(
     name: "Untitled workflow",
     nodes: [],
     edges: [],
+    origins: [],
   },
 ): { options: LifecycleOptions; callbacks: LifecycleCallbacks } {
   const document = {
     name: initialDocument.name,
     nodes: initialDocument.nodes,
     edges: initialDocument.edges,
+    origins: initialDocument.origins,
   };
   const callbacks = {
     replaceDocument: vi.fn((nextDocument: LifecycleOptions["document"]) => {
       document.name = nextDocument.name;
       document.nodes = nextDocument.nodes;
       document.edges = nextDocument.edges;
+      document.origins = nextDocument.origins;
     }),
     replacePresentation: vi.fn(),
     refreshNodeSecretStatuses,
@@ -225,6 +229,7 @@ describe("useSavedGraphLifecycle document ownership", () => {
       name: "Dragged graph",
       nodes: [node],
       edges: [],
+      origins: [],
     };
     api.createSavedGraph.mockResolvedValue(graph);
     api.getSavedGraph.mockResolvedValue(graph);
@@ -313,7 +318,8 @@ describe("useSavedGraphLifecycle document ownership", () => {
       name: "Live room edit",
       updated_at: "2026-08-13T12:00:00Z",
       document: {
-        schema_version: 6,
+        schema_version: 7,
+        origins: [],
         nodes: [{
             ...checkpointNode,
           input_plugs: [],
@@ -362,7 +368,8 @@ describe("useSavedGraphLifecycle document ownership", () => {
       name: "Checkpoint",
       updated_at: "2026-08-13T12:00:00Z",
       document: {
-        schema_version: 6,
+        schema_version: 7,
+        origins: [],
         nodes: [],
         edges: []
       }
@@ -437,7 +444,8 @@ describe("useSavedGraphLifecycle document ownership", () => {
         name: "Checkpoint",
         updated_at: "2026-08-13T12:00:00Z",
         document: {
-          schema_version: 6,
+          schema_version: 7,
+          origins: [],
           nodes: [checkpointedNode],
           edges: []
         }
@@ -500,7 +508,8 @@ describe("useSavedGraphLifecycle document ownership", () => {
       name: "Peer presentation",
       updated_at: "2026-08-13T12:00:00Z",
       document: {
-        schema_version: 6,
+        schema_version: 7,
+        origins: [],
         nodes: [],
         edges: [],
         presentation: peerPresentation
@@ -520,7 +529,8 @@ describe("useSavedGraphLifecycle document ownership", () => {
         name: "Checkpoint",
         updated_at: "2026-08-13T12:00:00Z",
         document: {
-          schema_version: 6,
+          schema_version: 7,
+          origins: [],
           nodes: [],
           edges: []
         }

--- a/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.ts
+++ b/apps/web/src/features/workbench/ui/useSavedGraphLifecycle.ts
@@ -250,7 +250,10 @@ export function useSavedGraphLifecycle({
   const showBlankGraph = React.useCallback(() => {
     documentGenerationRef.current += 1;
     openRequestRef.current?.abort();
-    replaceDocument({ name: NEW_GRAPH_NAME, nodes: [], edges: [] }, []);
+    replaceDocument(
+      { name: NEW_GRAPH_NAME, nodes: [], edges: [], origins: [] },
+      [],
+    );
     clearGraphSecretStatuses();
     setActiveGraph(null);
     setSavedFingerprint(null);
@@ -488,6 +491,7 @@ export function useSavedGraphLifecycle({
       name: NEW_GRAPH_NAME,
       nodes: [],
       edges: [],
+      origins: [],
     }, []);
     replacePresentation("", emptyGraphPresentation());
   }, [

--- a/apps/web/src/lib/api/contract.ts
+++ b/apps/web/src/lib/api/contract.ts
@@ -141,6 +141,7 @@ export type GraphMaterializations =
 export type SavedGraphDocument = Schemas["SavedGraphDocument"];
 export type SavedGraphNode = Schemas["SavedGraphNode"];
 export type SavedGraphEdge = Schemas["SavedGraphEdge"];
+export type SavedGraphOrigin = Schemas["SavedGraphOrigin"];
 export type SavedGraphSummary =
   Schemas["SavedGraphSummaryResponse"];
 export type GraphBrowserGraph = Schemas["GraphBrowserItemResponse"];

--- a/apps/web/src/lib/api/generated/grafy.ts
+++ b/apps/web/src/lib/api/generated/grafy.ts
@@ -1131,6 +1131,15 @@ export interface components {
             readonly kind: "add_node";
             readonly node: components["schemas"]["SavedGraphNode"];
         };
+        /** AddOriginCommand */
+        readonly AddOriginCommand: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            readonly kind: "add_origin";
+            readonly origin: components["schemas"]["SavedGraphOrigin"];
+        };
         /** ArtifactBundleContractResponse */
         readonly ArtifactBundleContractResponse: {
             /**
@@ -1375,6 +1384,8 @@ export interface components {
             readonly name: string;
             /** Nodes */
             readonly nodes: readonly components["schemas"]["SavedGraphNodeModel"][];
+            /** Origins */
+            readonly origins?: readonly components["schemas"]["SavedGraphOriginModel"][];
             readonly presentation?: components["schemas"]["GraphPresentationDocumentModel"];
             /**
              * Room Epoch
@@ -2714,6 +2725,16 @@ export interface components {
             /** Node Ids */
             readonly node_ids: readonly string[];
         };
+        /** RemoveOriginsCommand */
+        readonly RemoveOriginsCommand: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            readonly kind: "remove_origins";
+            /** Origin Ids */
+            readonly origin_ids: readonly string[];
+        };
         /** RenameGraphCommand */
         readonly RenameGraphCommand: {
             /** Expected Name */
@@ -2964,13 +2985,18 @@ export interface components {
              * @default []
              */
             readonly nodes: readonly components["schemas"]["SavedGraphNode"][];
+            /**
+             * Origins
+             * @default []
+             */
+            readonly origins: readonly components["schemas"]["SavedGraphOrigin"][];
             readonly presentation?: components["schemas"]["GraphPresentationDocument"];
             /**
              * Schema Version
-             * @default 6
+             * @default 7
              * @constant
              */
-            readonly schema_version: 6;
+            readonly schema_version: 7;
         };
         /** SavedGraphEdge */
         readonly SavedGraphEdge: {
@@ -3137,6 +3163,42 @@ export interface components {
             readonly position: components["schemas"]["GraphPointModel"];
         };
         /**
+         * SavedGraphOrigin
+         * @description Exact artifact value held on one node input with no incoming edge.
+         */
+        readonly SavedGraphOrigin: {
+            /**
+             * Conversion Path
+             * @default []
+             */
+            readonly conversion_path: readonly components["schemas"]["SavedGraphConversion"][];
+            /** Id */
+            readonly id: string;
+            /** To Node */
+            readonly to_node: string;
+            /** To Plug */
+            readonly to_plug?: string | null;
+            /** To Port */
+            readonly to_port: string;
+            /** Value */
+            readonly value: components["schemas"]["ArtifactRef"] | components["schemas"]["ArtifactRefSequence"];
+        };
+        /** SavedGraphOriginModel */
+        readonly SavedGraphOriginModel: {
+            /** Conversion Path */
+            readonly conversion_path?: readonly components["schemas"]["SavedGraphConversionModel"][];
+            /** Id */
+            readonly id: string;
+            /** To Node */
+            readonly to_node: string;
+            /** To Plug */
+            readonly to_plug?: string | null;
+            /** To Port */
+            readonly to_port: string;
+            /** Value */
+            readonly value: components["schemas"]["ArtifactRef"] | components["schemas"]["ArtifactRefSequence"];
+        };
+        /**
          * SavedGraphPluginReleasePin
          * @description Exact scoped Plugin release identity pinned on one graph node.
          *
@@ -3267,7 +3329,7 @@ export interface components {
         /** SubmitGraphCommandRequest */
         readonly SubmitGraphCommandRequest: {
             /** Command */
-            readonly command: components["schemas"]["RenameGraphCommand"] | components["schemas"]["AddNodeCommand"] | components["schemas"]["DuplicateNodeCommand"] | components["schemas"]["RemoveNodesCommand"] | components["schemas"]["MoveNodesCommand"] | components["schemas"]["UpdateNodeConfigurationCommand"] | components["schemas"]["UpdateNodeLayoutCommand"] | components["schemas"]["UpdateNodePluginReleaseCommand"] | components["schemas"]["SetNodeInputPlugsCommand"] | components["schemas"]["UpdateNodeConfigurationAndInputPlugsCommand"] | components["schemas"]["SetNodeArtifactTypeBindingCommand"] | components["schemas"]["ClearNodeArtifactTypeBindingCommand"] | components["schemas"]["AddEdgeCommand"] | components["schemas"]["UpdateEdgeCommand"] | components["schemas"]["RemoveEdgesCommand"] | components["schemas"]["ReplaceDocumentCommand"] | components["schemas"]["ReplacePresentationCommand"] | components["schemas"]["MoveArtifactViewersCommand"] | components["schemas"]["MoveAnnotationsCommand"];
+            readonly command: components["schemas"]["RenameGraphCommand"] | components["schemas"]["AddNodeCommand"] | components["schemas"]["DuplicateNodeCommand"] | components["schemas"]["RemoveNodesCommand"] | components["schemas"]["MoveNodesCommand"] | components["schemas"]["UpdateNodeConfigurationCommand"] | components["schemas"]["UpdateNodeLayoutCommand"] | components["schemas"]["UpdateNodePluginReleaseCommand"] | components["schemas"]["SetNodeInputPlugsCommand"] | components["schemas"]["UpdateNodeConfigurationAndInputPlugsCommand"] | components["schemas"]["SetNodeArtifactTypeBindingCommand"] | components["schemas"]["ClearNodeArtifactTypeBindingCommand"] | components["schemas"]["AddEdgeCommand"] | components["schemas"]["UpdateEdgeCommand"] | components["schemas"]["RemoveEdgesCommand"] | components["schemas"]["AddOriginCommand"] | components["schemas"]["UpdateOriginCommand"] | components["schemas"]["RemoveOriginsCommand"] | components["schemas"]["ReplaceDocumentCommand"] | components["schemas"]["ReplacePresentationCommand"] | components["schemas"]["MoveArtifactViewersCommand"] | components["schemas"]["MoveAnnotationsCommand"];
             /**
              * Command Id
              * Format: uuid
@@ -3562,6 +3624,16 @@ export interface components {
             /** Node Id */
             readonly node_id: string;
             readonly plugin_release_pin: components["schemas"]["SavedGraphPluginReleasePin"];
+        };
+        /** UpdateOriginCommand */
+        readonly UpdateOriginCommand: {
+            readonly expected_origin: components["schemas"]["SavedGraphOrigin"];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            readonly kind: "update_origin";
+            readonly origin: components["schemas"]["SavedGraphOrigin"];
         };
         /** UpdateSavedGraphRequest */
         readonly UpdateSavedGraphRequest: {

--- a/apps/web/src/lib/api/graph-head.ts
+++ b/apps/web/src/lib/api/graph-head.ts
@@ -4,11 +4,11 @@ import type { CollaborativeHead, LegacyCollaborativeHead } from "./contract";
 export function collaborativeHeadFromLegacy(
   head: LegacyCollaborativeHead,
 ): CollaborativeHead {
-  const { nodes, edges, presentation, ...metadata } = head;
+  const { nodes, edges, origins, presentation, ...metadata } = head;
   return {
     ...metadata,
     document: {
-      schema_version: 6,
+      schema_version: 7,
       nodes: nodes.map(({ plugin_release, ...node }) => ({
         ...node,
         artifact_type_bindings: node.artifact_type_bindings ?? [],
@@ -18,6 +18,10 @@ export function collaborativeHeadFromLegacy(
       edges: edges.map((edge) => ({
         ...edge,
         conversion_path: edge.conversion_path ?? [],
+      })),
+      origins: (origins ?? []).map((origin) => ({
+        ...origin,
+        conversion_path: origin.conversion_path ?? [],
       })),
       presentation: {
         viewers: presentation?.viewers ?? [],

--- a/apps/web/src/lib/api/workbench.test.ts
+++ b/apps/web/src/lib/api/workbench.test.ts
@@ -27,9 +27,10 @@ const WORKSPACE_ID = "workspace/1";
 describe("saved graph HTTP API", () => {
   it("writes and reads one canonical document shape", async () => {
     const document = {
-      schema_version: 6 as const,
+      schema_version: 7 as const,
       nodes: [],
       edges: [],
+      origins: [],
       presentation: {
         viewers: [],
         links: [],
@@ -118,7 +119,7 @@ describe("collaboration HTTP API", () => {
             checkpoint_revision: 1,
             name: "Draft",
             updated_at: "2026-08-07T00:00:00Z",
-            document: { schema_version: 6, nodes: [], edges: [] },
+            document: { schema_version: 7, nodes: [], edges: [], origins: [] },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -182,9 +183,10 @@ describe("collaboration HTTP API", () => {
       created_at: "2026-08-07T00:00:03Z",
       updated_at: "2026-08-07T00:00:03Z",
       document: {
-        schema_version: 6,
+        schema_version: 7,
         nodes: [],
         edges: [],
+        origins: [],
       },
     } satisfies CopyExactHeadResponse;
     const fetchMock = vi

--- a/libs/core/src/grafy_core/domain/collaboration.py
+++ b/libs/core/src/grafy_core/domain/collaboration.py
@@ -1,11 +1,11 @@
 """Collaborative graph head, commands, receipts, and checkpoints."""
 
+import hmac
+import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from hashlib import sha256
-import hmac
-import json
 from typing import Annotated, ClassVar, Literal, Self
 from uuid import UUID, uuid4
 
@@ -31,6 +31,7 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphInputPlug,
     SavedGraphNode,
     SavedGraphNodeLayout,
+    SavedGraphOrigin,
     SavedGraphPluginReleasePin,
 )
 
@@ -70,6 +71,9 @@ class GraphCommandKind(StrEnum):
     ADD_EDGE = "add_edge"
     UPDATE_EDGE = "update_edge"
     REMOVE_EDGES = "remove_edges"
+    ADD_ORIGIN = "add_origin"
+    UPDATE_ORIGIN = "update_origin"
+    REMOVE_ORIGINS = "remove_origins"
     REPLACE_DOCUMENT = "replace_document"
     REPLACE_PRESENTATION = "replace_presentation"
     MOVE_ARTIFACT_VIEWERS = "move_artifact_viewers"
@@ -215,6 +219,22 @@ class RemoveEdgesCommand(CollaborationValue):
     edge_ids: tuple[str, ...] = Field(min_length=1)
 
 
+class AddOriginCommand(CollaborationValue):
+    kind: Literal[GraphCommandKind.ADD_ORIGIN] = GraphCommandKind.ADD_ORIGIN
+    origin: SavedGraphOrigin
+
+
+class UpdateOriginCommand(CollaborationValue):
+    kind: Literal[GraphCommandKind.UPDATE_ORIGIN] = GraphCommandKind.UPDATE_ORIGIN
+    origin: SavedGraphOrigin
+    expected_origin: SavedGraphOrigin
+
+
+class RemoveOriginsCommand(CollaborationValue):
+    kind: Literal[GraphCommandKind.REMOVE_ORIGINS] = GraphCommandKind.REMOVE_ORIGINS
+    origin_ids: tuple[str, ...] = Field(min_length=1)
+
+
 class ReplaceDocumentCommand(CollaborationValue):
     kind: Literal[GraphCommandKind.REPLACE_DOCUMENT] = GraphCommandKind.REPLACE_DOCUMENT
     name: str
@@ -273,6 +293,9 @@ GraphCommand = Annotated[
     | AddEdgeCommand
     | UpdateEdgeCommand
     | RemoveEdgesCommand
+    | AddOriginCommand
+    | UpdateOriginCommand
+    | RemoveOriginsCommand
     | ReplaceDocumentCommand
     | ReplacePresentationCommand
     | MoveArtifactViewersCommand
@@ -357,6 +380,19 @@ def _edge_or_raise(document: SavedGraphDocument, edge_id: str) -> SavedGraphEdge
     raise CollaborationCommandRejectedError(
         code="missing_edge",
         message=f"Graph command targets missing edge {edge_id}",
+    )
+
+
+def _origin_or_raise(
+    document: SavedGraphDocument,
+    origin_id: str,
+) -> SavedGraphOrigin:
+    for origin in document.origins:
+        if origin.id == origin_id:
+            return origin
+    raise CollaborationCommandRejectedError(
+        code="missing_origin",
+        message=f"Graph command targets missing origin {origin_id}",
     )
 
 
@@ -501,6 +537,11 @@ def apply_graph_command(
                 edge
                 for edge in document.edges
                 if edge.from_node not in removed and edge.to_node not in removed
+            ),
+            origins=tuple(
+                origin
+                for origin in document.origins
+                if origin.to_node not in removed
             ),
             presentation=document.presentation.prune_for_removed_nodes(removed),
         )
@@ -647,6 +688,13 @@ def apply_graph_command(
                 or edge.to_plug is None
                 or edge.to_plug in retained_plug_ids
             ),
+            origins=tuple(
+                origin
+                for origin in document.origins
+                if origin.to_node != command.node_id
+                or origin.to_plug is None
+                or origin.to_plug in retained_plug_ids
+            ),
         )
 
     if isinstance(command, SetNodeArtifactTypeBindingCommand):
@@ -734,6 +782,45 @@ def apply_graph_command(
         return name, document.with_topology(
             edges=tuple(
                 edge for edge in document.edges if edge.id not in removed_edges
+            ),
+        )
+
+    if isinstance(command, AddOriginCommand):
+        if any(origin.id == command.origin.id for origin in document.origins):
+            raise CollaborationCommandRejectedError(
+                code="duplicate_origin",
+                message=f"Graph command adds duplicate origin {command.origin.id}",
+            )
+        return name, document.with_topology(
+            origins=(*document.origins, command.origin),
+        )
+
+    if isinstance(command, UpdateOriginCommand):
+        current = _origin_or_raise(document, command.origin.id)
+        if not _json_equal(
+            _model_json(current),
+            _model_json(command.expected_origin),
+        ):
+            raise _field_conflict(f"Origin {command.origin.id} changed")
+        if command.origin.id != command.expected_origin.id:
+            raise CollaborationCommandRejectedError(
+                code="invalid_origin_update",
+                message="Update origin command cannot change origin id",
+            )
+        return name, document.with_topology(
+            origins=tuple(
+                command.origin if origin.id == command.origin.id else origin
+                for origin in document.origins
+            ),
+        )
+
+    if isinstance(command, RemoveOriginsCommand):
+        removed_origins = set(command.origin_ids)
+        return name, document.with_topology(
+            origins=tuple(
+                origin
+                for origin in document.origins
+                if origin.id not in removed_origins
             ),
         )
 
@@ -931,6 +1018,7 @@ class GraphCheckpointMapping(BaseModel):
 __all__ = [
     "AddEdgeCommand",
     "AddNodeCommand",
+    "AddOriginCommand",
     "ClearNodeArtifactTypeBindingCommand",
     "CollaborationActorKind",
     "CollaborativeGraphHead",
@@ -949,6 +1037,7 @@ __all__ = [
     "MoveNodesCommand",
     "RemoveEdgesCommand",
     "RemoveNodesCommand",
+    "RemoveOriginsCommand",
     "RenameGraphCommand",
     "ReplaceDocumentCommand",
     "ReplacePresentationCommand",
@@ -959,6 +1048,7 @@ __all__ = [
     "UpdateNodeConfigurationCommand",
     "UpdateNodeLayoutCommand",
     "UpdateNodePluginReleaseCommand",
+    "UpdateOriginCommand",
     "apply_graph_command",
     "canonical_command_payload",
     "command_hmac_digest",

--- a/libs/core/src/grafy_core/domain/materialized_outputs.py
+++ b/libs/core/src/grafy_core/domain/materialized_outputs.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         SavedGraphDocument,
         SavedGraphEdge,
         SavedGraphNode,
+        SavedGraphOrigin,
     )
 
 
@@ -71,6 +72,23 @@ def _incoming_edge_signature(edge: "SavedGraphEdge") -> tuple[object, ...]:
     )
 
 
+def _incoming_origin_signature(origin: "SavedGraphOrigin") -> tuple[object, ...]:
+    # The value union carries no discriminator, so compare its exact JSON shape.
+    value = json.dumps(
+        origin.value.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return (
+        "origin",
+        origin.id,
+        origin.to_port,
+        origin.to_plug,
+        value,
+        tuple((step.id, step.version) for step in origin.conversion_path),
+    )
+
+
 def _incoming_edges_by_target(
     document: "SavedGraphDocument",
 ) -> dict[str, tuple[tuple[object, ...], ...]]:
@@ -82,6 +100,12 @@ def _incoming_edges_by_target(
         if not edge.enabled:
             continue
         grouped.setdefault(edge.to_node, []).append(_incoming_edge_signature(edge))
+    for origin in sorted(
+        document.origins, key=lambda origin: (origin.to_port, origin.to_plug or "")
+    ):
+        grouped.setdefault(origin.to_node, []).append(
+            _incoming_origin_signature(origin)
+        )
     return {node_id: tuple(signatures) for node_id, signatures in grouped.items()}
 
 
@@ -96,8 +120,9 @@ def materializations_for_compatible_nodes(
 
     Position, layout, and presentation may change across a saved revision without
     invalidating already materialized outputs. A change to a node's execution
-    identity or enabled inputs invalidates that node and every descendant along
-    enabled edges. Earlier revision bindings are retained unchanged.
+    identity or enabled inputs (edges and origins) invalidates that node and every
+    descendant along enabled edges. Earlier revision bindings are retained
+    unchanged.
     """
     if next_revision < 1:
         raise ValueError("Materialized output graph revision must be at least 1")

--- a/libs/core/src/grafy_core/domain/saved_graphs.py
+++ b/libs/core/src/grafy_core/domain/saved_graphs.py
@@ -16,12 +16,11 @@ from pydantic import (
     model_validator,
 )
 
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactRefSequence, ArtifactTypeKey
 from grafy_core.conversions import MAX_ARTIFACT_CONVERSION_HOPS
 from grafy_core.domain.errors import SavedGraphRevisionConflictError
 from grafy_core.domain.identity import WorkspaceKind
 from grafy_core.domain.plugin_identity import PluginReleaseScope
-
 
 GraphIdentifier = Annotated[
     str,
@@ -361,6 +360,30 @@ class SavedGraphEdge(SavedGraphValue):
     )
 
 
+class SavedGraphOrigin(SavedGraphValue):
+    """Exact artifact value held on one node input with no incoming edge."""
+
+    id: GraphIdentifier
+    to_node: GraphIdentifier
+    to_port: GraphIdentifier
+    to_plug: GraphIdentifier | None = None
+    value: ArtifactRef | ArtifactRefSequence
+    conversion_path: tuple[SavedGraphConversion, ...] = Field(
+        default=(),
+        max_length=MAX_ARTIFACT_CONVERSION_HOPS,
+    )
+
+
+def saved_graph_input_slot(
+    *,
+    to_node: str,
+    to_port: str,
+    to_plug: str | None,
+) -> tuple[str, str]:
+    """Identify one satisfiable input position for an edge or origin."""
+    return (to_node, to_plug if to_plug is not None else to_port)
+
+
 class GraphPresentationViewer(SavedGraphValue):
     id: GraphIdentifier
     position: GraphPoint
@@ -594,31 +617,40 @@ def empty_presentation() -> GraphPresentationDocument:
     return GraphPresentationDocument()
 
 
-SAVED_GRAPH_SCHEMA_VERSION = 6
+SAVED_GRAPH_SCHEMA_VERSION = 7
+
+# Version 6 documents stay readable; moving to 7 only added the optional
+# `origins` collection, which an absent field reads as empty.
+ACCEPTED_SAVED_GRAPH_SCHEMA_VERSIONS = (6, SAVED_GRAPH_SCHEMA_VERSION)
 
 
 class SavedGraphDocument(SavedGraphValue):
-    schema_version: Literal[6] = SAVED_GRAPH_SCHEMA_VERSION
+    schema_version: Literal[7] = SAVED_GRAPH_SCHEMA_VERSION
     nodes: tuple[SavedGraphNode, ...] = ()
     edges: tuple[SavedGraphEdge, ...] = ()
+    origins: tuple[SavedGraphOrigin, ...] = ()
     presentation: GraphPresentationDocument = Field(default_factory=empty_presentation)
 
     @model_validator(mode="before")
     @classmethod
-    def reject_legacy_document(cls, value: object) -> object:
+    def migrate_document_schema_version(cls, value: object) -> object:
         if not isinstance(value, Mapping):
             return value
         raw = cast(Mapping[object, object], value)
         version = raw.get("schema_version")
         if version is None:
             return value
-        if version != SAVED_GRAPH_SCHEMA_VERSION:
+        if version not in ACCEPTED_SAVED_GRAPH_SCHEMA_VERSIONS:
             raise ValueError(
                 "Saved graph document schema_version "
                 f"{version!r} is not supported; expected "
                 f"{SAVED_GRAPH_SCHEMA_VERSION}"
             )
-        return value
+        if version == SAVED_GRAPH_SCHEMA_VERSION:
+            return value
+        migrated = dict(raw)
+        migrated["schema_version"] = SAVED_GRAPH_SCHEMA_VERSION
+        return migrated
 
     @model_validator(mode="after")
     def validate_structure(self) -> Self:
@@ -629,6 +661,10 @@ class SavedGraphDocument(SavedGraphValue):
         edge_ids = [edge.id for edge in self.edges]
         if len(edge_ids) != len(set(edge_ids)):
             raise ValueError("Saved graph edge ids must be unique")
+
+        origin_ids = [origin.id for origin in self.origins]
+        if len(origin_ids) != len(set(origin_ids)):
+            raise ValueError("Saved graph origin ids must be unique")
 
         known_nodes = set(node_ids)
         plugs_by_node: dict[str, dict[str, SavedGraphInputPlug]] = {}
@@ -641,7 +677,17 @@ class SavedGraphDocument(SavedGraphValue):
             plugs_by_node[node.id] = {plug.id: plug for plug in node.input_plugs}
 
         connected_plugs: set[tuple[str, str]] = set()
+        enabled_slots: dict[tuple[str, str], str] = {}
         for edge in self.edges:
+            if edge.enabled:
+                enabled_slots.setdefault(
+                    saved_graph_input_slot(
+                        to_node=edge.to_node,
+                        to_port=edge.to_port,
+                        to_plug=edge.to_plug,
+                    ),
+                    edge.id,
+                )
             if edge.from_node not in known_nodes:
                 raise ValueError(
                     f"Saved graph edge {edge.id} references missing source node "
@@ -673,6 +719,38 @@ class SavedGraphDocument(SavedGraphValue):
                 )
             connected_plugs.add(plug_key)
 
+        for origin in self.origins:
+            if origin.to_node not in known_nodes:
+                raise ValueError(
+                    f"Saved graph origin {origin.id} references missing target node "
+                    f"{origin.to_node}"
+                )
+            if origin.to_plug is not None:
+                target_plug = plugs_by_node[origin.to_node].get(origin.to_plug)
+                if target_plug is None:
+                    raise ValueError(
+                        f"Saved graph origin {origin.id} references missing input "
+                        f"plug {origin.to_plug} on target node {origin.to_node}"
+                    )
+                if target_plug.port != origin.to_port:
+                    raise ValueError(
+                        f"Saved graph origin {origin.id} targets port "
+                        f"{origin.to_port}, but input plug {origin.to_plug} belongs "
+                        f"to port {target_plug.port}"
+                    )
+            slot = saved_graph_input_slot(
+                to_node=origin.to_node,
+                to_port=origin.to_port,
+                to_plug=origin.to_plug,
+            )
+            if slot in enabled_slots:
+                raise ValueError(
+                    f"Saved graph input {origin.to_plug or origin.to_port} on node "
+                    f"{origin.to_node} is already satisfied by edge "
+                    f"{enabled_slots[slot]}"
+                )
+            enabled_slots[slot] = origin.id
+
         for link in self.presentation.links:
             if link.source_node_id not in known_nodes:
                 raise ValueError(
@@ -686,11 +764,13 @@ class SavedGraphDocument(SavedGraphValue):
         *,
         nodes: tuple[SavedGraphNode, ...] | None = None,
         edges: tuple[SavedGraphEdge, ...] | None = None,
+        origins: tuple[SavedGraphOrigin, ...] | None = None,
         presentation: GraphPresentationDocument | None = None,
     ) -> "SavedGraphDocument":
         return SavedGraphDocument(
             nodes=self.nodes if nodes is None else nodes,
             edges=self.edges if edges is None else edges,
+            origins=self.origins if origins is None else origins,
             presentation=(self.presentation if presentation is None else presentation),
         )
 

--- a/tests/integration/saved_graphs/test_saved_graphs.py
+++ b/tests/integration/saved_graphs/test_saved_graphs.py
@@ -3,8 +3,6 @@ from typing import cast
 from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
-
-from grafy_api.v1.models import ArtifactTypeBindingModel, ArtifactTypeKeyResponse
 from grafy_api.graph_contracts import (
     CheckpointGraphRequest,
     CopyExactHeadRequest,
@@ -19,6 +17,7 @@ from grafy_api.graph_contracts import (
     SubmitGraphCommandRequest,
     UpdateSavedGraphRequest,
 )
+from grafy_api.v1.models import ArtifactTypeBindingModel, ArtifactTypeKeyResponse
 from grafy_core.domain.collaboration import RenameGraphCommand
 from grafy_core.domain.identity import ActorContext
 from grafy_core.domain.saved_graphs import SavedGraphDocument
@@ -190,9 +189,10 @@ def _canonical_raw_graph_payload(name: str = "Draft graph") -> dict[str, object]
     return {
         "name": payload.pop("name"),
         "document": {
-            "schema_version": 6,
+            "schema_version": 7,
             "nodes": payload.pop("nodes"),
             "edges": payload.pop("edges"),
+            "origins": [],
             "presentation": payload.pop("presentation"),
         },
     }
@@ -231,7 +231,7 @@ def test_saved_graph_crud_round_trip(builtin_client: TestClient) -> None:
     assert created["name"] == "Parish index draft"
     assert created["revision"] == 1
     document = created["document"]
-    assert document["schema_version"] == 6
+    assert document["schema_version"] == 7
     assert len(document["nodes"]) == 2
     assert len(document["edges"]) == 1
     assert document["nodes"][0]["input_plugs"] == []

--- a/tests/unit/api/test_graph_transport_conversion.py
+++ b/tests/unit/api/test_graph_transport_conversion.py
@@ -2,27 +2,28 @@
 
 from datetime import UTC, datetime
 from types import MappingProxyType
-from uuid import UUID
 from typing import Literal
+from uuid import UUID
 
 import pytest
-from pydantic import ValidationError
-
 from grafy_api.graph_contracts import (
     CanonicalCollaborativeHeadResponse,
     CollaborativeHeadResponse,
     SavedGraphEdgeModel,
-    SavedGraphNodeModel,
     SavedGraphNodeLayoutModel,
+    SavedGraphNodeModel,
+    SavedGraphOriginModel,
 )
 from grafy_core.domain.collaboration import CollaborativeGraphHead
 from grafy_core.domain.saved_graphs import (
-    SavedGraphDocument,
     GraphPresentationDocument,
+    SavedGraphDocument,
     SavedGraphEdge,
     SavedGraphNode,
     SavedGraphNodeLayout,
+    SavedGraphOrigin,
 )
+from pydantic import ValidationError
 
 
 @pytest.fixture
@@ -285,16 +286,81 @@ def test_node_models_require_release_pins_only_for_plugins(
             model.model_validate(payload)
 
 
+def test_origin_conversion_retains_exact_value_and_conversion_path(
+    head: CollaborativeGraphHead,
+) -> None:
+    payload = {
+        "id": "origin",
+        "to_node": "target",
+        "to_port": "input",
+        "to_plug": "plug",
+        "value": {
+            "artifact_id": "00000000-0000-0000-0000-0000000000a1",
+            "artifact_type": "scalar.text",
+            "schema_version": 1,
+            "content_hash": None,
+        },
+        "conversion_path": [{"id": "one", "version": 1}, {"id": "two", "version": 2}],
+    }
+    origin = SavedGraphOrigin.model_validate(payload)
+    head.document = SavedGraphDocument(
+        nodes=head.document.nodes,
+        origins=(origin,),
+    )
+
+    wire = CollaborativeHeadResponse.from_head(head).origins[0]
+
+    assert wire.model_dump(mode="json") == payload
+    assert SavedGraphOriginModel.model_validate(payload).model_dump(mode="json") == payload
+
+
+def test_origin_conversion_retains_an_artifact_ref_sequence(
+    head: CollaborativeGraphHead,
+) -> None:
+    payload: dict[str, object] = {
+        "id": "origin",
+        "to_node": "target",
+        "to_port": "input",
+        "value": {
+            "sequence_id": "00000000-0000-0000-0000-0000000000b1",
+            "artifact_type": "scalar.text",
+            "schema_version": 1,
+            "item_refs": [
+                {
+                    "artifact_id": "00000000-0000-0000-0000-0000000000a1",
+                    "artifact_type": "scalar.text",
+                    "schema_version": 1,
+                    "content_hash": None,
+                }
+            ],
+            "ordered": True,
+            "index_key": "order_index",
+            "metadata": {},
+        },
+    }
+    head.document = SavedGraphDocument(
+        nodes=head.document.nodes,
+        origins=(SavedGraphOrigin.model_validate(payload),),
+    )
+
+    wire = CollaborativeHeadResponse.from_head(head).origins[0]
+
+    assert wire.value.model_dump(mode="json") == payload["value"]
+
+
 def test_head_adapter_preserves_metadata_and_empty_document(head: CollaborativeGraphHead) -> None:
     head.document = SavedGraphDocument()
     canonical = CanonicalCollaborativeHeadResponse.from_head(head)
     legacy = CollaborativeHeadResponse.from_head(head)
-    assert legacy.model_dump(exclude={"nodes", "edges", "presentation"}) == canonical.model_dump(exclude={"document"})
+    assert legacy.model_dump(
+        exclude={"nodes", "edges", "origins", "presentation"}
+    ) == canonical.model_dump(exclude={"document"})
     assert legacy.collaboration_sequence == 8
     assert legacy.checkpoint_sequence == 3
     assert legacy.checkpoint_revision == 2
     assert legacy.nodes == []
     assert legacy.edges == []
+    assert legacy.origins == []
     assert legacy.presentation.model_dump(mode="json") == {"viewers": [], "links": [], "bindings": [], "annotations": []}
     payload = legacy.model_dump(mode="json")
     assert "document" not in payload

--- a/tests/unit/client/test_graph_builder.py
+++ b/tests/unit/client/test_graph_builder.py
@@ -1,7 +1,15 @@
 from typing import Annotated, ClassVar, override
 
 import pytest
-
+from grafy_client import (
+    CatalogConversion,
+    CatalogConversionKey,
+    CatalogNode,
+    CatalogPort,
+    GraphBuilder,
+    GraphBuilderError,
+    NodeCatalog,
+)
 from grafy_core.artifacts import (
     ArtifactRef,
     ArtifactRefSequence,
@@ -25,17 +33,6 @@ from grafy_core.nodes import (
     OutPort,
     PortShape,
 )
-
-from grafy_client import (
-    CatalogConversion,
-    CatalogConversionKey,
-    CatalogNode,
-    CatalogPort,
-    GraphBuilder,
-    GraphBuilderError,
-    NodeCatalog,
-)
-
 
 TEXT = ArtifactTypeKey("scalar.text", 1)
 MARKDOWN = ArtifactTypeKey("text.markdown", 1)
@@ -294,7 +291,7 @@ def test_builder_adds_typed_builtin_node_without_a_plugin_pin() -> None:
 
     assert text.node_id == "node-0001-text-input"
     assert document.model_dump(mode="json") == {
-        "schema_version": 6,
+        "schema_version": 7,
         "nodes": [
             {
                 "kind": "builtin",
@@ -310,6 +307,7 @@ def test_builder_adds_typed_builtin_node_without_a_plugin_pin() -> None:
             }
         ],
         "edges": [],
+        "origins": [],
         "presentation": {
             "viewers": [],
             "links": [],

--- a/tests/unit/core/test_collaboration.py
+++ b/tests/unit/core/test_collaboration.py
@@ -1,16 +1,15 @@
 from uuid import UUID, uuid4
 
 import pytest
-from pydantic import ValidationError
-
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.collaboration import (
+    GRAPH_COMMAND_ADAPTER,
     AddEdgeCommand,
     AddNodeCommand,
+    AddOriginCommand,
     ClearNodeArtifactTypeBindingCommand,
     CollaborativeGraphHead,
     DuplicateNodeCommand,
-    GRAPH_COMMAND_ADAPTER,
     MoveAnnotationPosition,
     MoveAnnotationsCommand,
     MoveArtifactViewerPosition,
@@ -19,6 +18,7 @@ from grafy_core.domain.collaboration import (
     MoveNodesCommand,
     RemoveEdgesCommand,
     RemoveNodesCommand,
+    RemoveOriginsCommand,
     RenameGraphCommand,
     ReplaceDocumentCommand,
     ReplacePresentationCommand,
@@ -29,6 +29,7 @@ from grafy_core.domain.collaboration import (
     UpdateNodeConfigurationCommand,
     UpdateNodeLayoutCommand,
     UpdateNodePluginReleaseCommand,
+    UpdateOriginCommand,
     apply_graph_command,
     command_hmac_digest,
     command_requires_exact_sequence,
@@ -50,8 +51,10 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphInputPlug,
     SavedGraphNode,
     SavedGraphNodeLayout,
+    SavedGraphOrigin,
     SavedGraphPluginReleasePin,
 )
+from pydantic import ValidationError
 
 
 def _node(
@@ -454,6 +457,107 @@ def test_update_node_plugin_release_serializes_and_is_not_exact_sequence() -> No
         ),
     )
     assert digest != moved_digest
+
+
+def _origin(origin_id: str = "o1", *, to_node: str = "n1") -> SavedGraphOrigin:
+    return SavedGraphOrigin(
+        id=origin_id,
+        to_node=to_node,
+        to_port="value",
+        value=ArtifactRef(
+            artifact_id=UUID("00000000-0000-0000-0000-000000000501"),
+            artifact_type="image.raster",
+            schema_version=1,
+        ),
+    )
+
+
+def test_add_update_and_remove_origins() -> None:
+    document = SavedGraphDocument(nodes=(_node("n1"),))
+    origin = _origin()
+
+    _, with_origin = apply_graph_command(
+        name="Graph",
+        document=document,
+        command=AddOriginCommand(origin=origin),
+    )
+    assert with_origin.origins == (origin,)
+
+    with pytest.raises(CollaborationCommandRejectedError) as duplicate:
+        apply_graph_command(
+            name="Graph",
+            document=with_origin,
+            command=AddOriginCommand(origin=origin),
+        )
+    assert duplicate.value.error_code == "duplicate_origin"
+
+    with pytest.raises(CollaborationCommandRejectedError) as conflict:
+        apply_graph_command(
+            name="Graph",
+            document=with_origin,
+            command=UpdateOriginCommand(
+                origin=origin.model_copy(update={"to_node": "n1"}),
+                expected_origin=origin.model_copy(update={"to_port": "absent"}),
+            ),
+        )
+    assert conflict.value.error_code == "field_conflict"
+
+    repointed = origin.model_copy(update={"value": origin.value.model_copy(update={"content_hash": "b" * 64})})
+    _, updated = apply_graph_command(
+        name="Graph",
+        document=with_origin,
+        command=UpdateOriginCommand(origin=repointed, expected_origin=origin),
+    )
+    assert updated.origins == (repointed,)
+
+    _, removed = apply_graph_command(
+        name="Graph",
+        document=updated,
+        command=RemoveOriginsCommand(origin_ids=("o1", "missing")),
+    )
+    assert removed.origins == ()
+
+
+def test_remove_nodes_prunes_origins_targeting_removed_nodes() -> None:
+    document = SavedGraphDocument(
+        nodes=(_node("n1"), _node("n2")),
+        origins=(_origin(), _origin("o2", to_node="n2")),
+    )
+
+    _, remaining = apply_graph_command(
+        name="Graph",
+        document=document,
+        command=RemoveNodesCommand(node_ids=("n1",)),
+    )
+
+    assert [origin.id for origin in remaining.origins] == ["o2"]
+
+
+def test_plug_edit_prunes_origins_on_removed_plugs() -> None:
+    target = SavedGraphNode(
+        kind="builtin",
+        id="target",
+        operator_id="example.operator",
+        operator_version=1,
+        position=GraphPoint(x=0, y=0),
+        input_plugs=(SavedGraphInputPlug(id="plug-a", port="value"),),
+    )
+    origin = _origin(to_node="target").model_copy(update={"to_plug": "plug-a"})
+    document = SavedGraphDocument(nodes=(target,), origins=(origin,))
+
+    _, remaining = apply_graph_command(
+        name="Graph",
+        document=document,
+        command=UpdateNodeConfigurationAndInputPlugsCommand(
+            node_id="target",
+            config={},
+            input_plugs=(),
+            expected_config={},
+            expected_plug_ids=("plug-a",),
+        ),
+    )
+
+    assert remaining.origins == ()
 
 
 def test_add_edge_and_sanitize_copy_document() -> None:

--- a/tests/unit/core/test_materialized_output_carry_forward.py
+++ b/tests/unit/core/test_materialized_output_carry_forward.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 import pytest
-
 from grafy_core.artifacts import ArtifactRef
 from grafy_core.domain.materialized_outputs import (
     MaterializedNodeOutputs,
@@ -16,9 +15,9 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphInputPlug,
     SavedGraphNode,
     SavedGraphNodeLayout,
+    SavedGraphOrigin,
     SavedGraphProjection,
 )
-
 
 WORKSPACE_ID = UUID("00000000-0000-0000-0000-000000000007")
 GRAPH_ID = UUID("00000000-0000-0000-0000-000000000101")
@@ -47,6 +46,23 @@ def _edge(edge_id: str, source: str, target: str) -> SavedGraphEdge:
         from_port="result",
         to_node=target,
         to_port="value",
+    )
+
+
+def _origin(
+    origin_id: str = "origin",
+    *,
+    artifact_id: str = "00000000-0000-0000-0000-000000000401",
+) -> SavedGraphOrigin:
+    return SavedGraphOrigin(
+        id=origin_id,
+        to_node="target",
+        to_port="value",
+        value=ArtifactRef(
+            artifact_id=UUID(artifact_id),
+            artifact_type="scalar.integer",
+            schema_version=1,
+        ),
     )
 
 
@@ -273,6 +289,72 @@ def test_changed_input_invalidates_target_and_descendants(
     )
 
     assert {item.node_id for item in carried} == {"source", "other"}
+
+
+def test_placing_an_origin_invalidates_target_and_descendants() -> None:
+    nodes = (_node("target"), _node("downstream"), _node("unrelated"))
+    downstream_edge = _edge("e2", "target", "downstream")
+    previous = SavedGraphDocument(nodes=nodes, edges=(downstream_edge,))
+    next_document = SavedGraphDocument(
+        nodes=nodes,
+        edges=(downstream_edge,),
+        origins=(_origin(),),
+    )
+
+    carried = materializations_for_compatible_nodes(
+        previous_document=previous,
+        next_document=next_document,
+        previous_materializations=[_materialization(node.id) for node in nodes],
+        next_revision=2,
+    )
+
+    assert [item.node_id for item in carried] == ["unrelated"]
+
+
+@pytest.mark.parametrize(
+    "changed_origin",
+    [
+        pytest.param(None, id="removed"),
+        pytest.param(
+            _origin(artifact_id="00000000-0000-0000-0000-000000000402"),
+            id="replaced-value",
+        ),
+        pytest.param(
+            _origin().model_copy(
+                update={
+                    "conversion_path": (
+                        SavedGraphConversion(id="as-text", version=1),
+                    )
+                }
+            ),
+            id="conversion",
+        ),
+    ],
+)
+def test_changing_an_origin_invalidates_target_and_descendants(
+    changed_origin: SavedGraphOrigin | None,
+) -> None:
+    nodes = (_node("target"), _node("downstream"), _node("unrelated"))
+    downstream_edge = _edge("e2", "target", "downstream")
+    previous = SavedGraphDocument(
+        nodes=nodes,
+        edges=(downstream_edge,),
+        origins=(_origin(),),
+    )
+    next_document = SavedGraphDocument(
+        nodes=nodes,
+        edges=(downstream_edge,),
+        origins=() if changed_origin is None else (changed_origin,),
+    )
+
+    carried = materializations_for_compatible_nodes(
+        previous_document=previous,
+        next_document=next_document,
+        previous_materializations=[_materialization(node.id) for node in nodes],
+        next_revision=2,
+    )
+
+    assert [item.node_id for item in carried] == ["unrelated"]
 
 
 def test_disabled_edge_does_not_propagate_invalidation() -> None:

--- a/tests/unit/core/test_saved_graphs.py
+++ b/tests/unit/core/test_saved_graphs.py
@@ -3,9 +3,7 @@ from typing import cast
 from uuid import UUID
 
 import pytest
-from pydantic import ValidationError
-
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactRefSequence, ArtifactTypeKey
 from grafy_core.domain.errors import SavedGraphRevisionConflictError
 from grafy_core.domain.plugin_releases import PluginReleaseScope
 from grafy_core.domain.saved_graphs import (
@@ -15,15 +13,16 @@ from grafy_core.domain.saved_graphs import (
     SavedGraph,
     SavedGraphAnnotationLayout,
     SavedGraphArtifactTypeBinding,
-    SavedGraphDocument,
     SavedGraphConversion,
+    SavedGraphDocument,
     SavedGraphEdge,
     SavedGraphInputPlug,
     SavedGraphNode,
     SavedGraphNodeLayout,
+    SavedGraphOrigin,
     SavedGraphPluginReleasePin,
 )
-
+from pydantic import ValidationError
 
 WORKSPACE_ID = UUID("00000000-0000-0000-0000-000000000901")
 
@@ -62,6 +61,26 @@ def _edge(
         from_port="result",
         to_node=to_node,
         to_port="value",
+    )
+
+
+def _origin(
+    origin_id: str = "origin",
+    *,
+    to_node: str = "target",
+    to_port: str = "value",
+    to_plug: str | None = None,
+) -> SavedGraphOrigin:
+    return SavedGraphOrigin(
+        id=origin_id,
+        to_node=to_node,
+        to_port=to_port,
+        to_plug=to_plug,
+        value=ArtifactRef(
+            artifact_id=UUID("00000000-0000-0000-0000-000000000401"),
+            artifact_type="image.raster",
+            schema_version=1,
+        ),
     )
 
 
@@ -122,7 +141,7 @@ def test_saved_graph_document_requires_current_schema_version() -> None:
         )
     )
 
-    assert document.schema_version == 6
+    assert document.schema_version == 7
     assert document.nodes[0].artifact_type_binding_map() == {
         "T": ArtifactTypeKey("example.value", 2)
     }
@@ -426,6 +445,146 @@ def test_saved_graph_document_rejects_edges_to_missing_nodes(
         SavedGraphDocument(
             nodes=(_node("source"), _node("target")),
             edges=(edge,),
+        )
+
+
+def test_saved_graph_document_reads_version_six_with_empty_origins() -> None:
+    document = SavedGraphDocument.model_validate(
+        {
+            "schema_version": 6,
+            "nodes": [_node("source").model_dump(mode="json")],
+            "edges": [],
+        }
+    )
+
+    assert document.schema_version == 7
+    assert document.origins == ()
+
+
+def test_saved_graph_origin_round_trips_an_exact_reference() -> None:
+    origin = _origin().model_copy(
+        update={"conversion_path": (SavedGraphConversion(id="as-text", version=1),)}
+    )
+    document = SavedGraphDocument(
+        nodes=(_node("target"),),
+        origins=(origin,),
+    )
+
+    payload = document.model_dump(mode="json")
+
+    assert payload["origins"][0]["value"]["artifact_type"] == "image.raster"
+    assert payload["origins"][0]["conversion_path"] == [
+        {"id": "as-text", "version": 1}
+    ]
+    assert SavedGraphDocument.model_validate(payload).origins[0].value == origin.value
+
+
+def test_saved_graph_origin_accepts_an_artifact_ref_sequence() -> None:
+    sequence = ArtifactRefSequence(
+        artifact_type="image.raster",
+        schema_version=1,
+        item_refs=[
+            ArtifactRef(
+                artifact_id=UUID("00000000-0000-0000-0000-000000000401"),
+                artifact_type="image.raster",
+                schema_version=1,
+            )
+        ],
+    )
+
+    origin = SavedGraphOrigin(
+        id="origin",
+        to_node="target",
+        to_port="value",
+        value=sequence,
+    )
+
+    assert isinstance(origin.value, ArtifactRefSequence)
+
+
+def test_saved_graph_document_requires_unique_origin_ids() -> None:
+    with pytest.raises(ValidationError, match="origin ids must be unique"):
+        SavedGraphDocument(
+            nodes=(_node("target"),),
+            origins=(_origin(), _origin()),
+        )
+
+
+def test_saved_graph_document_requires_origins_to_reference_existing_nodes() -> None:
+    with pytest.raises(ValidationError, match="missing target node absent"):
+        SavedGraphDocument(
+            nodes=(_node("target"),),
+            origins=(_origin(to_node="absent"),),
+        )
+
+
+def test_saved_graph_document_requires_origin_plug_to_exist_and_match_port() -> None:
+    target = _node(
+        "target",
+        input_plugs=(SavedGraphInputPlug(id="item", port="items"),),
+    )
+
+    with pytest.raises(ValidationError, match="missing input plug absent"):
+        SavedGraphDocument(
+            nodes=(target,),
+            origins=(_origin(to_port="items", to_plug="absent"),),
+        )
+
+    with pytest.raises(ValidationError, match="belongs to port items"):
+        SavedGraphDocument(
+            nodes=(target,),
+            origins=(_origin(to_port="value", to_plug="item"),),
+        )
+
+
+def test_saved_graph_document_allows_one_origin_per_input_slot() -> None:
+    target = _node(
+        "target",
+        input_plugs=(SavedGraphInputPlug(id="item", port="items"),),
+    )
+    origin = _origin(to_port="items", to_plug="item")
+
+    document = SavedGraphDocument(nodes=(target,), origins=(origin,))
+
+    assert document.origins == (origin,)
+
+    with pytest.raises(ValidationError, match="already satisfied"):
+        SavedGraphDocument(
+            nodes=(target,),
+            origins=(origin, origin.model_copy(update={"id": "second"})),
+        )
+
+
+def test_saved_graph_document_origin_conflicts_with_enabled_edge_only() -> None:
+    target = _node(
+        "target",
+        input_plugs=(SavedGraphInputPlug(id="item", port="items"),),
+    )
+    origin = _origin(to_port="items", to_plug="item")
+    edge = _edge("plugged").model_copy(
+        update={"to_port": "items", "to_plug": "item"}
+    )
+
+    disabled_edge_document = SavedGraphDocument(
+        nodes=(_node("source"), target),
+        edges=(edge.model_copy(update={"enabled": False}),),
+        origins=(origin,),
+    )
+    assert disabled_edge_document.origins == (origin,)
+
+    with pytest.raises(ValidationError, match="already satisfied"):
+        SavedGraphDocument(
+            nodes=(_node("source"), target),
+            edges=(edge,),
+            origins=(origin,),
+        )
+
+
+def test_saved_graph_document_rejects_two_origins_on_one_unplugged_port() -> None:
+    with pytest.raises(ValidationError, match="already satisfied"):
+        SavedGraphDocument(
+            nodes=(_node("target"),),
+            origins=(_origin("first"), _origin("second")),
         )
 
 

--- a/tests/unit/persistence/test_saved_graph_persistence.py
+++ b/tests/unit/persistence/test_saved_graph_persistence.py
@@ -5,10 +5,7 @@ from pathlib import Path
 from uuid import UUID
 
 import pytest
-from sqlalchemy import text
-from sqlalchemy.exc import IntegrityError
-
-from grafy_core.artifacts import ArtifactTypeKey
+from grafy_core.artifacts import ArtifactRef, ArtifactTypeKey
 from grafy_core.domain.errors import ConcurrentWriteError
 from grafy_core.domain.saved_graphs import (
     GraphFolder,
@@ -21,15 +18,16 @@ from grafy_core.domain.saved_graphs import (
     SavedGraphEdge,
     SavedGraphInputPlug,
     SavedGraphNode,
+    SavedGraphOrigin,
     SavedGraphProjection,
     SavedGraphRevision,
     UserGraphState,
 )
-
 from grafy_persistence.database import Database, create_database
 from grafy_persistence.orm import metadata
 from grafy_persistence.unit_of_work import SqlAlchemySavedGraphUnitOfWork
-
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 
 WORKSPACE_ID = UUID("00000000-0000-0000-0000-000000000001")
 OTHER_WORKSPACE_ID = UUID("00000000-0000-0000-0000-000000000002")
@@ -110,6 +108,21 @@ def _document(label: str = "draft") -> SavedGraphDocument:
                     ),
                 ),
                 route_offset=GraphPoint(x=4.0, y=-8.0),
+            ),
+        ),
+        origins=(
+            SavedGraphOrigin(
+                id="target-fallback",
+                to_node="target",
+                to_port="fallback",
+                value=ArtifactRef(
+                    artifact_id=UUID("00000000-0000-0000-0000-0000000000a1"),
+                    artifact_type="scalar.text",
+                    schema_version=1,
+                ),
+                conversion_path=(
+                    SavedGraphConversion(id="example.text.normalize", version=2),
+                ),
             ),
         ),
     )
@@ -308,7 +321,7 @@ async def test_sql_json_loads_then_updates_current_documents_in_a_fresh_session(
     async with SqlAlchemySavedGraphUnitOfWork(database.sessions) as unit_of_work:
         loaded = await unit_of_work.graphs.get(WORKSPACE_ID, graph_id)
         assert loaded is not None
-        assert loaded.document.schema_version == 6
+        assert loaded.document.schema_version == 7
         assert loaded.document.edges[0].conversion_path == (
             SavedGraphConversion(id="example.text.normalize", version=2),
         )
@@ -341,7 +354,7 @@ async def test_sql_json_loads_then_updates_current_documents_in_a_fresh_session(
         )
     assert isinstance(raw_document, str)
     stored_document = json.loads(raw_document)
-    assert stored_document["schema_version"] == 6
+    assert stored_document["schema_version"] == 7
     assert "conversion" not in stored_document["edges"][0]
     assert stored_document["edges"][0]["conversion_path"] == [
         {"id": "example.text.normalize", "version": 2}
@@ -353,7 +366,7 @@ async def test_sql_json_loads_then_updates_current_documents_in_a_fresh_session(
     assert reloaded is not None
     assert reloaded.name == "Updated graph"
     assert reloaded.revision == 2
-    assert reloaded.document.schema_version == 6
+    assert reloaded.document.schema_version == 7
     assert reloaded.document.nodes[1].artifact_type_binding_map() == {
         "T": ArtifactTypeKey("scalar.text", 1)
     }


### PR DESCRIPTION
Closes #37.

Adds `SavedGraphDocument.origins` so a node input can hold an exact artifact value with no incoming edge, and raises the saved-graph schema to 7 while still accepting 6 (a missing `origins` reads as empty).

## Contract

- `SavedGraphOrigin` with `id`, `to_node`, `to_port`, `to_plug`, `value`, `conversion_path` in `libs/core/src/grafy_core/domain/saved_graphs.py`. `value` is the same `ArtifactRef | ArtifactRefSequence` union as `PinnedOutputRequest.value`, with no discriminator tag.
- `SAVED_GRAPH_SCHEMA_VERSION` 6 -> 7. `6` is still accepted and migrated; a missing `origins` reads as empty.
- Structural checks in `validate_structure`: unique origin ids; target node exists; a named `to_plug` exists and belongs to `to_port`; at most one satisfier per slot counting enabled edges and origins together, where a slot is `(to_node, to_plug)` for a plug port else `(to_node, to_port)`. A disabled edge may sit beside an origin.

## Changes

- **core**: `AddOriginCommand`, `UpdateOriginCommand` (CAS via `expected_origin`) and `RemoveOriginsCommand`, alongside the existing edge commands; origins are pruned when a node is removed or an input plug is edited.
- **core**: origins are included in the per-target input signature in `_incoming_edges_by_target`, so placing, changing or removing an origin invalidates the target and its descendants. `_node_execution_signature` is unchanged.
- **api**: `CollaborativeHeadResponse` mirrors `origins`.
- **web**: mirrors the document field and the semantic command union, maps the new commands over the room protocol in both directions, and the OpenAPI client is regenerated.

Canvas drop handling for origins is out of scope here (tracked by later issues under #19).

## Verification

- `uv run --all-extras pytest`: 1737 passed, 42 skipped.
- `npm --prefix apps/web test`: 620 passed; `typecheck`, `lint`, `check:api` and the production `build` are clean.
- `just lint` (`ruff check`) clean; `basedpyright` introduces no new errors (21 pre-existing -> 20).

### Pre-existing issues (not introduced here, verified against the base commit)

- `tests/integration/executions/test_plugin_egress_docker.py::test_docker_runtime_routes_historical_network_egress_through_live_broker` fails identically on the base commit. The fixture appends `class NetworkProbeInput(NodeInput)` to `examples/plugin-notes/.../nodes.py`, which never imports `NodeInput`, so collection fails with a `NameError`. Untouched by this branch and out of scope.
- The secret scan reports four findings in files this branch never modifies: an e2e TLS private key committed as a local test fixture (`infra/e2e/tls/server.key`, added by `01d94db`), a design-doc phrase ("node-secret values, encryption/HMAC"), a Python module path string in an import-boundary test, and a fake PEM whose body is base64 of the word `secret` in a negative test. Flagged for maintainer review rather than removed, since deleting the e2e key would break the e2e suite.
- `Workbench.tsx` carries a narrow `pi-lens-ignore: no-open-redirect` on the pre-existing `window.open` that opens an internal graph route. The rule matches any `window.open` call syntactically, while the target here is a same-origin path built from `encodeURIComponent`'d route params.

## Follow-up risk

`sanitize_document_for_cross_workspace_copy` builds its `SavedGraphDocument` without passing `origins`, so origins are dropped on cross-workspace copy. That matches its existing artifact-reference-stripping intent, but it is a behaviour change worth an explicit decision.
