### PR TITLE
test(plugins): test egress against the current contract, not a historical one

### DIFF
--- a/docs/features/network-access-profiles/README.md
+++ b/docs/features/network-access-profiles/README.md
@@ -854,26 +854,11 @@ It must emit a deprecation warning that names the replacement manifest.
 
 The broker image remains pinned by immutable SHA-256 digest.
 
-### 17.2 Existing Plugin releases
+### 17.2 Pre-cutover Plugin releases
 
-Historical releases with `network.egress` but no HTTP destination declaration
-must not be assigned invented config fields.
-
-- They may run only under the legacy-curated compatibility profile or an exact
-  administrator allowlist that preserves their previous authority.
-- They are not eligible for `configured-public` based on inference from
-  operator identity or config field names.
-- Republished releases must satisfy the new explicit contract validation.
-
-New serialized contract fields require empty defaults so old manifests remain
-readable. Catalog-digest compatibility must be tested explicitly: parsing an
-old release and applying a new default must not make Grafy falsely claim that
-its historically persisted digest described different bytes. Use an explicit
-contract-version or legacy canonicalization rule when empty-field
-serialization would otherwise change the digest.
-
-This preserves exact historical facts while moving new publication to the
-safer contract.
+The cutover migration discards pre-existing Plugin release rows, so no
+compatibility obligation is owed to historical `network.egress` releases.
+Operators republish from the checked-in source and wheelhouse.
 
 ### 17.3 Graph documents and node secrets
 
@@ -1004,8 +989,6 @@ runtime.
 - [ ] Capability review shows configured fields and dynamic-destination state.
 - [ ] A Plugin cannot name or alter its assigned profile.
 - [ ] Missing or invalid profile assignments fail closed.
-- [ ] Historical releases remain runnable only through explicit legacy or
-      curated compatibility policy.
 
 ### 19.2 Configured-public execution
 
@@ -1074,7 +1057,7 @@ runtime.
 | Contract serialization | Round trip, digest changes, missing capability, missing config field, dynamic flag |
 | URL normalization | Case, trailing dot, default/explicit port, IDN policy, userinfo, malformed port, duplicate origins |
 | DNS safety | Public IPv4/IPv6, private answer, mixed answer, empty answer, timeout, rebinding-resistant numeric connect |
-| Admission | Offline, configured, curated intersection, dynamic denial, open-public grant, historical release |
+| Admission | Offline, configured, curated intersection, dynamic denial, open-public grant |
 | Preflight | Actual node config, safe errors, origin count, profile assignment changes |
 | Sandbox identity | Same/different origin, same/different profile digest, PostgreSQL coexistence |
 | Broker | Exact CONNECT match, forbidden origin, limits, cleanup, open-public resolution mode |

--- a/tests/integration/executions/test_plugin_egress_docker.py
+++ b/tests/integration/executions/test_plugin_egress_docker.py
@@ -50,6 +50,7 @@ from grafy_api.plugins.runtime.egress import (
 from grafy_api.plugins.profiles import runtime_profile
 from grafy_api.plugins.publication.oci import PluginOciImageBuilder
 from grafy_api.plugins.publication.source import PluginDirectoryPublisher
+from grafy_api.plugins.publication.workflow import require_network_contract
 from grafy_api.plugins.runtime.artifacts import ArtifactBundlePluginInvoker
 from grafy_api.plugins.runtime.docker import DockerPluginRuntime
 from grafy_api.plugins.runtime.sandbox import (
@@ -60,6 +61,7 @@ from grafy_api.plugins.runtime.sandbox import (
 
 
 WORKSPACE_ID = UUID("00000000-0000-4000-8000-000000000952")
+PROBE_URL = "http://example.com/"
 
 
 @dataclass
@@ -153,8 +155,23 @@ def _network_egress_plugin(repository: Path, destination: Path) -> Path:
         + """
 
 import urllib.request
+from typing import Annotated
 
+from pydantic import StrictStr
+
+from grafy_core.artifact_contracts import TEXT_VALUE, TextValue
+from grafy_core.artifacts import NodeConfig, NodeInput, NodeOutput
 from grafy_core.domain.plugin_capabilities import PluginRuntimeCapability
+from grafy_core.nodes import OutPort
+from grafy_core.plugins import (
+    NodeCachePolicy,
+    NodeHttpEgressContract,
+    NodeHttpEgressInput,
+)
+
+
+class NetworkProbeConfig(NodeConfig):
+    url: StrictStr
 
 
 class NetworkProbeInput(NodeInput):
@@ -170,17 +187,17 @@ class NetworkProbeOutput(NodeOutput):
     version=1,
     title="Network probe",
     required_capabilities=(PluginRuntimeCapability.NETWORK_EGRESS,),
+    http_egress=NodeHttpEgressContract(
+        configured_inputs=(NodeHttpEgressInput(config_field="url"),),
+    ),
     cache_policy=NodeCachePolicy.NEVER,
 )
 async def network_probe(
-    _config: NoConfig,
+    _config: NetworkProbeConfig,
     _inputs: NetworkProbeInput,
 ) -> NetworkProbeOutput:
-    try:
-        with urllib.request.urlopen("http://example.com/", timeout=10) as response:
-            body = response.read(4_096).decode("utf-8")
-    except Exception as exc:
-        body = f"{type(exc).__name__}: {exc}"
+    with urllib.request.urlopen(_config.url, timeout=10) as response:
+        body = response.read(4_096).decode("utf-8")
     return NetworkProbeOutput(text=TextValue(value=body))
 """,
         encoding="utf-8",
@@ -243,7 +260,7 @@ async def network_probe(
 
 
 @pytest.mark.asyncio
-async def test_docker_runtime_routes_historical_network_egress_through_live_broker(
+async def test_docker_runtime_routes_network_egress_through_live_broker(
     tmp_path: Path,
 ) -> None:
     if not _docker_available():
@@ -346,6 +363,9 @@ async def test_docker_runtime_routes_historical_network_egress_through_live_brok
         assert verified.capabilities.capabilities == (
             PluginRuntimeCapability.NETWORK_EGRESS,
         )
+        # The fixture must remain a release the current publication rules would
+        # accept: network.egress nodes declare where their destinations come from.
+        require_network_contract(verified.catalog)
         source_digest = sha256(verified.source_archive).hexdigest()
         contract_digest = plugin_contract_digest(verified.catalog)
         profile_digest = plugin_profile_digest(verified.runtime_profile)
@@ -359,9 +379,6 @@ async def test_docker_runtime_routes_historical_network_egress_through_live_brok
             candidate=verified,
         )
         plugin_image = f"sha256:{artifact.manifest_digest}"
-        # Construct the release directly because this fixture models a persisted
-        # historical catalog that predates HTTP egress contracts. The current
-        # publication workflow rejects a newly published equivalent.
         release_record = PluginRelease(
             slug=verified.catalog.slug,
             revision=1,
@@ -398,22 +415,21 @@ async def test_docker_runtime_routes_historical_network_egress_through_live_brok
             host="example.com",
             port=80,
         )
-        # The probe node declares NETWORK_EGRESS without an http_egress
-        # contract, so it needs a curated legacy-compatibility profile
-        # (spec §17.2) allowing its exact plain-HTTP origin.
-        legacy_egress = NetworkAccessProfile(
-            name="legacy-egress",
+        # The probe takes its origin from a node config field; the deployment's
+        # curated profile still bounds that request to this exact origin.
+        curated_egress = NetworkAccessProfile(
+            name="curated-egress",
             plane=NetworkAccessPlane.PLUGIN_EXECUTION,
             mode=NetworkProfileMode.CURATED,
             https_only=False,
             allowed_origins=(probe_destination,),
         )
         network_policy = NetworkPolicy(
-            profiles={(legacy_egress.plane, legacy_egress.name): legacy_egress},
+            profiles={(curated_egress.plane, curated_egress.name): curated_egress},
             assignments=(
                 NetworkProfileAssignment(
-                    plane=legacy_egress.plane,
-                    profile=legacy_egress.name,
+                    plane=curated_egress.plane,
+                    profile=curated_egress.name,
                     scope=PluginReleaseScope.WORKSPACE,
                     workspace_id=WORKSPACE_ID,
                     slug="notes",
@@ -459,7 +475,7 @@ async def test_docker_runtime_routes_historical_network_egress_through_live_brok
                 workspace_id=WORKSPACE_ID,
                 node_id="network-egress-probe",
             ),
-            node.config_contract.model.model_validate({}),
+            node.config_contract.model.model_validate({"url": PROBE_URL}),
             node.input_contract.model.model_validate({}),
         )
         text_ref = cast(ArtifactRef, output.__dict__["text"])


### PR DESCRIPTION
## Why

The network-access-profiles spec promised compatibility to historical `network.egress`
Plugin releases (spec §17.2, plus an acceptance criterion and a test-matrix row). That
promise cannot be honoured: the cutover migration
(`infra/db/migrations/versions/0026_drop_plugin_distribution.py`) `DELETE`s
`plugin_releases` (and the rest of the plugin-distribution tables) in `_wipe_cutover_rows`.
No pre-cutover release row survives, so there is no compatibility obligation to keep —
only an unenforceable claim in the docs.

To reach that claim, the Docker egress integration test had to hand-build a
`PluginRelease` bypassing publication, because the current `require_network_contract`
gate (correctly) rejects a `network.egress` node with no HTTP egress contract. The test
therefore asserted behaviour of a release shape the product no longer produces.

## What changed

**Spec** (`docs/features/network-access-profiles/README.md`)

- §17.2 now states the fact: the cutover migration discards pre-existing Plugin release
  rows, no compatibility obligation is owed, operators republish from checked-in source
  and wheelhouse. Heading renamed to *Pre-cutover Plugin releases*.
- Dropped the "Historical releases remain runnable…" acceptance criterion.
- Dropped `historical release` from the Admission test-matrix row.

**Test** (`tests/integration/executions/test_plugin_egress_docker.py`)

- Probe node is now a normal release: `NetworkProbeConfig` with a `url` field, declaring
  `NodeHttpEgressContract(configured_inputs=(NodeHttpEgressInput(config_field="url"),))`.
- Profile renamed `legacy-egress` to `curated-egress`; the deployment's curated profile
  still bounds the request to the exact origin.
- Dropped the `try/except` that swallowed egress failures — a denied request must fail
  the test, not be recorded as plugin output.
- The fixture now passes through `require_network_contract`, so the test cannot silently
  drift away from what publication accepts.
- Test renamed `...routes_historical_network_egress...` to
  `...routes_network_egress_through_live_broker`.

The broker isolation assertions are unchanged: sandbox on an `--internal` network, broker
on both networks, `--network` values as before.

## Also fixes main's red Backend tests job

The appended fixture snippet referenced `NodeInput`/`NodeOutput`/`TextValue` without
importing them, since `4d7d65b` migrated `examples/plugin-notes` to `callable_node`. The
rewritten snippet is self-sufficient, which clears the
`PluginPublishingError: Plugin tests failed with exit code 2` →
`NameError: name 'NodeInput' is not defined` failure.

## Verification

- `tests/integration/executions/test_plugin_egress_docker.py` → `1 passed` (~12s).
- Falsification: pointing `PROBE_URL` at `http://example.org/` fails with
  `Network egress denied (network_destination_not_allowlisted)`, so the test is not
  vacuous.
- `ruff check` clean on the repo's CI paths.
